### PR TITLE
Connect to API via https

### DIFF
--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -66,7 +66,7 @@ module Notifications
       # @raise [RequestError] if request is
       #   not successful
       def perform_request!(request)
-        response = http.request(request)
+        response = open(request)
         if response.is_a?(Net::HTTPClientError)
           raise RequestError.new(response)
         else
@@ -74,9 +74,11 @@ module Notifications
         end
       end
 
-      def http
+      def open(request)
         uri = URI.parse(@base_url)
-        Net::HTTP.new(uri.host, uri.port)
+        Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+          http.request(request)
+        end
       end
 
       def headers

--- a/spec/notifications/client/get_notification_spec.rb
+++ b/spec/notifications/client/get_notification_spec.rb
@@ -23,7 +23,7 @@ describe Notifications::Client do
     before do
       stub_request(
         :get,
-        "#{uri.host}:#{uri.port}/notifications/#{id}"
+        "https://#{uri.host}:#{uri.port}/notifications/#{id}"
       ).to_return(body: mocked_response.to_json)
     end
 

--- a/spec/notifications/client/get_notifications_spec.rb
+++ b/spec/notifications/client/get_notifications_spec.rb
@@ -19,7 +19,7 @@ describe Notifications::Client do
     before do
       stub_request(
         :get,
-        "#{uri.host}:#{uri.port}/notifications/"
+        "https://#{uri.host}:#{uri.port}/notifications/"
       ).to_return(body: mocked_response.to_json)
     end
 
@@ -66,7 +66,7 @@ describe Notifications::Client do
     before do
       stub_request(
         :get,
-        "#{uri.host}:#{uri.port}/notifications/?#{request_path}"
+        "https://#{uri.host}:#{uri.port}/notifications/?#{request_path}"
       ).to_return(body: mocked_response.to_json)
     end
 
@@ -74,7 +74,7 @@ describe Notifications::Client do
       notifications
       expect(WebMock).to have_requested(
         :get,
-        "#{uri.host}:#{uri.port}/notifications/"
+        "https://#{uri.host}:#{uri.port}/notifications/"
       ).with(query: options)
     end
 

--- a/spec/notifications/client/request_errors_spec.rb
+++ b/spec/notifications/client/request_errors_spec.rb
@@ -15,7 +15,7 @@ describe Notifications::Client do
     before do
       stub_request(
         :get,
-        "#{uri.host}:#{uri.port}/notifications/1"
+        "https://#{uri.host}:#{uri.port}/notifications/1"
       ).to_return(
         status: 403,
         body: error_response.to_json

--- a/spec/support/stub_post_request.rb
+++ b/spec/support/stub_post_request.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples "stub_post_request" do |kind|
   before do
     stub_request(
       :post,
-      "#{uri.host}:#{uri.port}/notifications/#{kind}"
+      "https://#{uri.host}:#{uri.port}/notifications/#{kind}"
     ).to_return(
       body: mocked_response.to_json,
       status: 201,


### PR DESCRIPTION
Changed `Net::HTTP.new` to `Net::HTTP.start` to use 
inbuild https vertification and setup

Without this change the API attempts to connect via HTTP regards of API URLs protocol and returns: 
```Errno::ECONNRESET: Connection reset by peer``` 
when trying to send emails.

