### PR TITLE
Update Bundler version to run tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
- - 2.2
+ - 2.2.2

--- a/notifications-ruby-client.gemspec
+++ b/notifications-ruby-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jwt", "~> 1.5"
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.0"


### PR DESCRIPTION
Trying to run the tests for this repo on Travis gives the following error:
```
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.11) ruby
  Current Bundler version:
    bundler (1.7.9)
```

This seems to be because we’re using quite an old version of the `bundler` Gem.

Also updates Travis config to use a newer Ruby for the same reason.