### PR TITLE
Update notifications response object

### DIFF
--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -45,7 +45,7 @@ module Notifications
     # @return [Notification]
     def get_notification(id)
       Notification.new(
-        speaker.get(id)["data"]["notification"]
+        speaker.get(id)
       )
     end
 

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -26,7 +26,7 @@ module Notifications
     # @return [ResponseNotification]
     def send_email(args)
       ResponseNotification.new(
-        speaker.send(:post, "email", args)
+        speaker.post("email", args)
       )
     end
 
@@ -35,7 +35,7 @@ module Notifications
     # @return [ResponseNotification]
     def send_sms(args)
       ResponseNotification.new(
-        speaker.send(:post, "sms", args)
+        speaker.post("sms", args)
       )
     end
 
@@ -45,7 +45,7 @@ module Notifications
     # @return [Notification]
     def get_notification(id)
       Notification.new(
-        speaker.send(:get, id)["data"]["notification"]
+        speaker.get(id)["data"]["notification"]
       )
     end
 
@@ -63,7 +63,7 @@ module Notifications
     # @return [NotificationsCollection]
     def get_notifications(options = {})
       NotificationsCollection.new(
-        speaker.send(:get, nil, options)
+        speaker.get(nil, options)
       )
     end
   end

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -45,7 +45,7 @@ module Notifications
     # @return [Notification]
     def get_notification(id)
       Notification.new(
-        speaker.send(:get, id)["notification"]
+        speaker.send(:get, id)["data"]["notification"]
       )
     end
 

--- a/lib/notifications/client/notification.rb
+++ b/lib/notifications/client/notification.rb
@@ -24,6 +24,8 @@ module Notifications
       attr_reader(*FIELDS)
 
       def initialize(notification)
+        notification = normalize(notification)
+
         FIELDS.each do |field|
           instance_variable_set(
             :"@#{field}",
@@ -45,6 +47,12 @@ module Notifications
             value
           end
         end
+      end
+
+      private
+
+      def normalize(notification)
+        notification.key?('data') ? notification['data']['notification'] : notification
       end
     end
   end

--- a/lib/notifications/client/notification.rb
+++ b/lib/notifications/client/notification.rb
@@ -3,17 +3,22 @@ module Notifications
     class Notification
       FIELDS = [
         :id,
+        :api_key,
+        :billable_units,
         :to,
+        :subject,
+        :body,
         :job,
+        :notification_type,
         :status,
         :service,
         :sent_at,
         :sent_by,
         :template,
+        :template_version,
         :reference,
         :created_at,
-        :updated_at,
-        :content_char_count
+        :updated_at
       ].freeze
 
       attr_reader(*FIELDS)

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -49,15 +49,11 @@ module Notifications
       # @param id [String]
       # @param options [Hash] query
       # @see #perform_request!
-      def get(id = nil, options = nil)
-        if !options.nil? && options.keys.any?
-          path = "?" + URI.encode_www_form(options)
-        end
-
-        request = Net::HTTP::Get.new(
-          "#{BASE_PATH}/#{id}#{path}",
-          headers
-        )
+      def get(id = nil, options = {})
+        path = BASE_PATH.dup
+        path << "/" << id if id
+        path << "?" << URI.encode_www_form(options) if options.any?
+        request = Net::HTTP::Get.new(path, headers)
         perform_request!(request)
       end
 

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -24,8 +24,6 @@ module Notifications
         @base_url = base_url || PRODUCTION_BASE_URL
       end
 
-    private
-
       ##
       # @param kind [String] 'email' or 'sms'
       # @param form_data [Hash]
@@ -56,6 +54,8 @@ module Notifications
         request = Net::HTTP::Get.new(path, headers)
         perform_request!(request)
       end
+
+      private
 
       ##
       # @return [Hash] JSON parsed response

--- a/spec/factories/client_notifications.rb
+++ b/spec/factories/client_notifications.rb
@@ -24,10 +24,15 @@ FactoryGirl.define do
               "original_file_name" => "Test run"
             },
             "id" => "f163deaf-2d3f-4ec6-98fc-f23fa511518f",
-            "content_char_count" => 490,
             "service" => "5cf87313-fddd-4482-a2ea-48e37320efd1",
             "reference" => "None",
-            "sent_by" => "mmg"
+            "sent_by" => "mmg",
+            "api_key" => "Test API key",
+            "billable_units" => 0,
+            "body" => "Test body",
+            "notification_type" => "email",
+            "subject" => "Test subject",
+            "template_version" => 10
           }
         }
       }

--- a/spec/factories/client_notifications.rb
+++ b/spec/factories/client_notifications.rb
@@ -7,26 +7,28 @@ FactoryGirl.define do
 
     body do
       {
-        "notification" => {
-          "status" => "delivered",
-          "to" => "07515 987 456",
-          "template" => {
-            "id" => "5e427b42-4e98-46f3-a047-32c4a87d26bb",
-            "name" => "First template",
-            "template_type" => "sms"
-          },
-          "created_at" => "2016-04-26T15:29:36.891512+00:00",
-          "updated_at" => "2016-04-26T15:29:38.724808+00:00",
-          "sent_at" => "2016-04-26T15:29:37.230976+00:00",
-          "job" => {
-            "id" => "f9043884-acac-46db-b2ea-f08cd8ec6d67",
-            "original_file_name" => "Test run"
-          },
-          "id" => "f163deaf-2d3f-4ec6-98fc-f23fa511518f",
-          "content_char_count" => 490,
-          "service" => "5cf87313-fddd-4482-a2ea-48e37320efd1",
-          "reference" => "None",
-          "sent_by" => "mmg"
+        "data" => {
+          "notification" => {
+            "status" => "delivered",
+            "to" => "07515 987 456",
+            "template" => {
+              "id" => "5e427b42-4e98-46f3-a047-32c4a87d26bb",
+              "name" => "First template",
+              "template_type" => "sms"
+            },
+            "created_at" => "2016-04-26T15:29:36.891512+00:00",
+            "updated_at" => "2016-04-26T15:29:38.724808+00:00",
+            "sent_at" => "2016-04-26T15:29:37.230976+00:00",
+            "job" => {
+              "id" => "f9043884-acac-46db-b2ea-f08cd8ec6d67",
+              "original_file_name" => "Test run"
+            },
+            "id" => "f163deaf-2d3f-4ec6-98fc-f23fa511518f",
+            "content_char_count" => 490,
+            "service" => "5cf87313-fddd-4482-a2ea-48e37320efd1",
+            "reference" => "None",
+            "sent_by" => "mmg"
+          }
         }
       }
     end

--- a/spec/factories/client_notifications_collections.rb
+++ b/spec/factories/client_notifications_collections.rb
@@ -14,7 +14,7 @@ FactoryGirl.define do
           "next" => "/notifications?page=3&template_type=sms&status=delivered"
         },
         "notifications" => 2.times.map {
-          attributes_for(:client_notification)[:body]["notification"]
+          attributes_for(:client_notification)[:body]["data"]["notification"]
         }
       }
     end

--- a/spec/notifications/client/get_notifications_spec.rb
+++ b/spec/notifications/client/get_notifications_spec.rb
@@ -19,7 +19,7 @@ describe Notifications::Client do
     before do
       stub_request(
         :get,
-        "https://#{uri.host}:#{uri.port}/notifications/"
+        "https://#{uri.host}:#{uri.port}/notifications"
       ).to_return(body: mocked_response.to_json)
     end
 
@@ -66,15 +66,15 @@ describe Notifications::Client do
     before do
       stub_request(
         :get,
-        "https://#{uri.host}:#{uri.port}/notifications/?#{request_path}"
+        "https://#{uri.host}:#{uri.port}/notifications?#{request_path}"
       ).to_return(body: mocked_response.to_json)
     end
 
-    it "expect to request with right parameters " do
+    it "expect to request with right parameters" do
       notifications
       expect(WebMock).to have_requested(
         :get,
-        "https://#{uri.host}:#{uri.port}/notifications/"
+        "https://#{uri.host}:#{uri.port}/notifications"
       ).with(query: options)
     end
 


### PR DESCRIPTION
Fixes for:
* get_notification -> update hash nesting in response JSON
* get_notifications -> incorrect URL - remove trailing slash
* field list -> remove old field - content_char_count

Update
* field list -> add new fields

This has been tested again the live system for the pensionwise account.