### PR TITLE
Prepare for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@
 /pkg/
 /spec/reports/
 /tmp/
+.DS_Store
+/vendor
+environment.sh
+/.idea/
+/.idea/vcs.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -1,0 +1,156 @@
+#!/usr/bin/env ruby
+require "notifications/client"
+require "notifications/client/notification"
+require "notifications/client/response_notification"
+require "notifications/client/notification"
+
+def main
+	client = Notifications::Client.new(ENV["SERVICE_ID"],
+		ENV["API_KEY"], ENV["NOTIFY_API_URL"])
+	email_notification = test_send_email_endpoint(client)
+	sms_notification = test_send_sms_endpoint(client)
+	sleep 2
+	notification = test_get_notification_by_id_endpoint(client, email_notification.id, 'email')
+	notification_sms = test_get_notification_by_id_endpoint(client, sms_notification.id, 'sms')
+	test_get_all_notifications(client, sms_notification.id, email_notification.id)
+	p 'ruby client functional tests pass'
+	exit 0
+
+end
+
+def test_send_email_endpoint(client)
+	email_resp = client.send_email(to: ENV["FUNCTIONAL_TEST_EMAIL"], template: ENV["EMAIL_TEMPLATE_ID"])
+	test_notification_response_data_type(email_resp, 'email')
+	email_resp
+end
+
+def test_send_sms_endpoint(client)
+	sms_resp = client.send_sms(to: ENV["FUNCTIONAL_TEST_NUMBER"], template: ENV["SMS_TEMPLATE_ID"])
+	test_notification_response_data_type(sms_resp, 'sms')
+	sms_resp
+end
+
+def test_notification_response_data_type(notification, message_type)
+	unless notification.is_a?(Notifications::Client::ResponseNotification) then
+		p 'failed ' + message_type +' response is not a Notifications::Client::ResponseNotification'
+		exit 1
+	end
+	unless notification.id.is_a?(String) then
+		p 'failed '+ message_type + 'id is not a String'
+		exit 1
+	end
+end
+
+def test_get_notification_by_id_endpoint(client, id, message_type)
+	get_notification_response = client.get_notification(id)
+	unless get_notification_response.is_a?(Notifications::Client::Notification) then
+		p 'get notification is not a Notifications::Client::Notification for id ' + id
+		exit 1
+	end
+	if message_type == 'email' then
+		field_should_not_be_nil(expected_fields_in_email_resp, get_notification_response, 'send_email')
+		field_should_be_nil(expected_fields_in_email_resp_that_are_nil, get_notification_response, 'send_email')
+	end
+	if message_type == 'sms' then
+		field_should_not_be_nil(expected_fields_in_sms_resp, get_notification_response, 'send_sms')
+		field_should_be_nil(expected_fields_in_sms_resp_that_are_nil, get_notification_response, 'send_sms')
+	end
+	get_notification_response
+end
+
+def field_should_not_be_nil(fields, obj, method_name)
+	fields.each do |field|
+		if obj.send(:"#{field}") == nil then
+			  p 'contract test failed because ' + field + ' should not be nil for ' + method_name + ' response'
+	    	exit 1
+	    end
+	end
+end
+def field_should_be_nil(fields, obj, method_name)
+	fields.each do |field|
+		if obj.send(:"#{field}") != nil then
+			p 'contract test failed because ' + field + ' should be nil for ' + method_name + ' response'
+	    	exit 1
+	    end
+	end
+end
+
+def expected_fields_in_email_resp
+	%w(id
+		 api_key
+		 billable_units
+		 to
+		 subject
+		 body
+		 notification_type
+		 status
+		 service
+		 sent_at
+		 sent_by
+		 template
+		 template_version
+		 created_at
+		 updated_at
+		 )
+end
+
+def expected_fields_in_email_resp_that_are_nil
+ %w(job)
+end
+
+def expected_fields_in_sms_resp
+%w(id
+   api_key
+   billable_units
+   to
+   body
+   notification_type
+   status
+   service
+   sent_at
+   sent_by
+   template
+   template_version
+   created_at
+   updated_at
+   )
+end
+
+def expected_fields_in_sms_resp_that_are_nil
+ %w(job
+  subject
+	reference)
+end
+
+def test_get_all_notifications(client, first_id, second_id)
+	notifications = client.get_notifications()
+	unless notifications.is_a?(Notifications::Client::NotificationsCollection) then
+		p 'notifications is not Notifications::Client::NotificationsCollection'
+		exit 1
+	end
+
+	field_should_not_be_nil(expected_fields_for_get_all_notifications, notifications, 'get_notifications')
+
+	notification_collection = notifications.send(:"collection")
+	unless notification_collection[0].id == first_id then
+		p 'first item in notification_collection is not expected notificaitons, last message sent'
+		exit 0
+	end
+	unless notification_collection[1].id == second_id then
+		p 'second item in notification_collection is not expected notificaitons, second last message sent'
+		exit 0
+	end
+
+end
+
+def expected_fields_for_get_all_notifications
+%W(links
+	total
+	page_size
+	collection
+	)
+end
+
+if __FILE__ == $PROGRAM_NAME
+	main
+end

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -1,105 +1,132 @@
 #!/usr/bin/env ruby
-require "notifications/client"
-require "notifications/client/notification"
-require "notifications/client/response_notification"
-require "notifications/client/notification"
+require 'notifications/client'
+require 'notifications/client/notification'
+require 'notifications/client/response_notification'
+require 'notifications/client/notification'
 
 def main
-	client = Notifications::Client.new(ENV["SERVICE_ID"],
-		ENV["API_KEY"], ENV["NOTIFY_API_URL"])
-	email_notification = test_send_email_endpoint(client)
-	sms_notification = test_send_sms_endpoint(client)
-	sleep 2
-	notification = test_get_notification_by_id_endpoint(client, email_notification.id, 'email')
-	notification_sms = test_get_notification_by_id_endpoint(client, sms_notification.id, 'sms')
-	test_get_all_notifications(client, sms_notification.id, email_notification.id)
-	p 'ruby client functional tests pass'
-	exit 0
-
+  client = Notifications::Client.new(ENV['SERVICE_ID'], ENV['API_KEY'], ENV['NOTIFY_API_URL'])
+  email_notification = test_send_email_endpoint(client)
+  sms_notification = test_send_sms_endpoint(client)
+  test_get_notification_by_id_endpoint(client, email_notification.id, 'email')
+  test_get_notification_by_id_endpoint(client, sms_notification.id, 'sms')
+  test_get_all_notifications(client, sms_notification.id, email_notification.id)
+  p 'ruby client functional tests pass'
+  exit 0
 end
 
 def test_send_email_endpoint(client)
-	email_resp = client.send_email(to: ENV["FUNCTIONAL_TEST_EMAIL"], template: ENV["EMAIL_TEMPLATE_ID"])
-	test_notification_response_data_type(email_resp, 'email')
-	email_resp
+  email_resp = client.send_email(to: ENV['FUNCTIONAL_TEST_EMAIL'], template: ENV['EMAIL_TEMPLATE_ID'])
+  test_notification_response_data_type(email_resp, 'email')
+  email_resp
 end
 
 def test_send_sms_endpoint(client)
-	sms_resp = client.send_sms(to: ENV["FUNCTIONAL_TEST_NUMBER"], template: ENV["SMS_TEMPLATE_ID"])
-	test_notification_response_data_type(sms_resp, 'sms')
-	sms_resp
+  sms_resp = client.send_sms(to: ENV['FUNCTIONAL_TEST_NUMBER'], template: ENV['SMS_TEMPLATE_ID'])
+  test_notification_response_data_type(sms_resp, 'sms')
+  sms_resp
 end
 
 def test_notification_response_data_type(notification, message_type)
-	unless notification.is_a?(Notifications::Client::ResponseNotification) then
-		p 'failed ' + message_type +' response is not a Notifications::Client::ResponseNotification'
-		exit 1
-	end
-	unless notification.id.is_a?(String) then
-		p 'failed '+ message_type + 'id is not a String'
-		exit 1
-	end
+  unless notification.is_a?(Notifications::Client::ResponseNotification) then
+    p 'failed ' + message_type +' response is not a Notifications::Client::ResponseNotification'
+    exit 1
+  end
+  unless notification.id.is_a?(String) then
+    p 'failed '+ message_type + 'id is not a String'
+    exit 1
+  end
 end
 
 def test_get_notification_by_id_endpoint(client, id, message_type)
-	get_notification_response = client.get_notification(id)
-	unless get_notification_response.is_a?(Notifications::Client::Notification) then
-		p 'get notification is not a Notifications::Client::Notification for id ' + id
-		exit 1
-	end
-	if message_type == 'email' then
-		field_should_not_be_nil(expected_fields_in_email_resp, get_notification_response, 'send_email')
-		field_should_be_nil(expected_fields_in_email_resp_that_are_nil, get_notification_response, 'send_email')
-	end
-	if message_type == 'sms' then
-		field_should_not_be_nil(expected_fields_in_sms_resp, get_notification_response, 'send_sms')
-		field_should_be_nil(expected_fields_in_sms_resp_that_are_nil, get_notification_response, 'send_sms')
-	end
-	get_notification_response
+  get_notification_response = get_notification_for_id(client, id, message_type)
+  unless get_notification_response.is_a?(Notifications::Client::Notification) then
+    p 'get notification is not a Notifications::Client::Notification for id ' + id
+    exit 1
+  end
+  if message_type == 'email' then
+    field_should_not_be_nil(expected_fields_in_email_resp, get_notification_response, 'send_email')
+    field_should_be_nil(expected_fields_in_email_resp_that_are_nil, get_notification_response, 'send_email')
+  end
+  if message_type == 'sms' then
+    field_should_not_be_nil(expected_fields_in_sms_resp, get_notification_response, 'send_sms')
+    field_should_be_nil(expected_fields_in_sms_resp_that_are_nil, get_notification_response, 'send_sms')
+  end
+end
+
+
+def get_notification_for_id(client, id, message_type)
+  max_attempts = 0
+  wait_for_sent_message = true
+  while max_attempts < 3 && wait_for_sent_message
+    begin
+      get_notification_response = client.get_notification(id)
+      wait_for_sent_message = false
+    rescue Notifications::Client::RequestError => no_result
+      if no_result.message == "No result found"
+        max_attempts = max_attempts + 1
+        sleep 3
+      else
+        p 'get_notification threw an exception for the ' + message_type + ' notification'
+        p no_result.to_s
+        exit 1
+      end
+    end
+    if get_notification_response != nil && get_notification_response.send(:'status') == 'created'
+      # we want to test the sent response?
+      wait_for_sent_message = true
+    end
+  end
+  if max_attempts == 3 then
+    p 'get_notification failed because the ' + message_type + ' notification was not found'
+    exit 1
+  end
+  get_notification_response
 end
 
 def field_should_not_be_nil(fields, obj, method_name)
-	fields.each do |field|
-		if obj.send(:"#{field}") == nil then
-			  p 'contract test failed because ' + field + ' should not be nil for ' + method_name + ' response'
-	    	exit 1
-	    end
-	end
+  fields.each do |field|
+    if obj.send(:"#{field}") == nil then
+      p 'contract test failed because ' + field + ' should not be nil for ' + method_name + ' response'
+      exit 1
+    end
+  end
 end
+
 def field_should_be_nil(fields, obj, method_name)
-	fields.each do |field|
-		if obj.send(:"#{field}") != nil then
-			p 'contract test failed because ' + field + ' should be nil for ' + method_name + ' response'
-	    	exit 1
-	    end
-	end
+  fields.each do |field|
+    if obj.send(:"#{field}") != nil then
+      p 'contract test failed because ' + field + ' should be nil for ' + method_name + ' response'
+      exit 1
+    end
+  end
 end
 
 def expected_fields_in_email_resp
-	%w(id
-		 api_key
-		 billable_units
-		 to
-		 subject
-		 body
-		 notification_type
-		 status
-		 service
-		 sent_at
-		 sent_by
-		 template
-		 template_version
-		 created_at
-		 updated_at
-		 )
+  %w(id
+     api_key
+     billable_units
+     to
+     subject
+     body
+     notification_type
+     status
+     service
+     sent_at
+     sent_by
+     template
+     template_version
+     created_at
+     updated_at
+)
 end
 
 def expected_fields_in_email_resp_that_are_nil
- %w(job)
+  %w(job)
 end
 
 def expected_fields_in_sms_resp
-%w(id
+  %w(id
    api_key
    billable_units
    to
@@ -117,34 +144,33 @@ def expected_fields_in_sms_resp
 end
 
 def expected_fields_in_sms_resp_that_are_nil
- %w(job
+  %w(job
   subject
 	reference)
 end
 
 def test_get_all_notifications(client, first_id, second_id)
-	notifications = client.get_notifications()
-	unless notifications.is_a?(Notifications::Client::NotificationsCollection) then
-		p 'notifications is not Notifications::Client::NotificationsCollection'
-		exit 1
-	end
+  notifications = client.get_notifications()
+  unless notifications.is_a?(Notifications::Client::NotificationsCollection) then
+    p 'get all notifications is not Notifications::Client::NotificationsCollection'
+    exit 1
+  end
 
-	field_should_not_be_nil(expected_fields_for_get_all_notifications, notifications, 'get_notifications')
+  field_should_not_be_nil(expected_fields_for_get_all_notifications, notifications, 'get_notifications')
 
-	notification_collection = notifications.send(:"collection")
-	unless notification_collection[0].id == first_id then
-		p 'first item in notification_collection is not expected notificaitons, last message sent'
-		exit 0
-	end
-	unless notification_collection[1].id == second_id then
-		p 'second item in notification_collection is not expected notificaitons, second last message sent'
-		exit 0
-	end
-
+  notification_collection = notifications.send(:'collection')
+  unless notification_collection[0].id == first_id then
+    p 'first item in notification_collection is not the expected notification, last message sent'
+    exit 0
+  end
+  unless notification_collection[1].id == second_id then
+    p 'second item in notification_collection is not the expected notification, second last message sent'
+    exit 0
+  end
 end
 
 def expected_fields_for_get_all_notifications
-%W(links
+  %W(links
 	total
 	page_size
 	collection
@@ -152,5 +178,5 @@ def expected_fields_for_get_all_notifications
 end
 
 if __FILE__ == $PROGRAM_NAME
-	main
+  main
 end

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -40,7 +40,7 @@ module Notifications
     end
 
     ##
-    # @param id [Integer]
+    # @param id [String]
     # @see Notifications::Client::Speaker#get
     # @return [Notification]
     def get_notification(id)

--- a/lib/notifications/client/notification.rb
+++ b/lib/notifications/client/notification.rb
@@ -27,10 +27,10 @@ module Notifications
         notification = normalize(notification)
 
         FIELDS.each do |field|
-          instance_variable_set(
-            :"@#{field}",
-            notification.fetch(field.to_s)
-          )
+            instance_variable_set(
+              :"@#{field}",
+              notification.fetch(field.to_s, nil)
+            )
         end
       end
 

--- a/lib/notifications/client/notification.rb
+++ b/lib/notifications/client/notification.rb
@@ -27,9 +27,7 @@ module Notifications
         notification = normalize(notification)
 
         FIELDS.each do |field|
-            instance_variable_set(
-              :"@#{field}",
-              notification.fetch(field.to_s, nil)
+            instance_variable_set(:"@#{field}", notification.fetch(field.to_s, nil)
             )
         end
       end

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -39,7 +39,7 @@ module Notifications
           "#{BASE_PATH}/#{kind}",
           headers
         )
-        request.body = form_data
+        request.body = form_data.is_a?(Hash) ? form_data.to_json : form_data
         perform_request!(request)
       end
 

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -1,5 +1,5 @@
 module Notifications
   class Client
-    VERSION = "0.0.1".freeze
+    VERSION = "1.0.0".freeze
   end
 end


### PR DESCRIPTION
- Added a bin/test_client.rb in order to do end to end testing.  …
- Updated the notifications object to default to nil if the attribute is missing.
  The sms notification response does not include the subject, but email does.
  The end-to-end tests should fail if an attribute is missing.
- Set the version to 1.0.0, as we plan to deploy this version to rubygems
- allow the post data for send_email/send_sms to be a Hash or a String
- Update README.md
- Finish bin/test_client.rb hopefully this is maintainable and readable now.