### PR TITLE
Make secret include API key + service ID

### DIFF
--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -11,7 +11,9 @@ module Notifications
 
     PRODUCTION_BASE_URL = "https://api.notifications.service.gov.uk".freeze
 
-    delegate :base_url,
+    delegate :service_id,
+             :secret_token,
+             :base_url,
              :base_url=,
              to: :speaker
 

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -7,6 +7,8 @@ module Notifications
   class Client
     class Speaker
       attr_reader :base_url
+      attr_reader :service_id
+      attr_reader :secret_token
 
       BASE_PATH = "/notifications".freeze
       USER_AGENT = "NOTIFY-API-RUBY-CLIENT/#{Notifications::Client::VERSION}".freeze
@@ -18,10 +20,20 @@ module Notifications
       #   secret
       # @param base_url [String] host URL. This is
       #   the address to perform the requests
-      def initialize(service_id, secret_token, base_url = nil)
-        @service_id = service_id
-        @secret_token = secret_token
-        @base_url = base_url || PRODUCTION_BASE_URL
+      def initialize(service_id, secret_token = nil, base_url = nil)
+        if secret_token == nil and base_url == nil
+          @service_id = service_id[service_id.length - 73..service_id.length - 38]
+          @secret_token = service_id[service_id.length - 36..service_id.length]
+          @base_url = PRODUCTION_BASE_URL
+        elsif secret_token.start_with?("http") and base_url == nil
+          @service_id = service_id[service_id.length - 73..service_id.length - 38]
+          @secret_token = service_id[service_id.length - 36..service_id.length]
+          @base_url = secret_token
+        else
+          @service_id = service_id
+          @secret_token = secret_token[secret_token.length - 36..secret_token.length]
+          @base_url = base_url || PRODUCTION_BASE_URL
+        end
       end
 
       ##

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -1,5 +1,5 @@
 module Notifications
   class Client
-    VERSION = "1.0.0".freeze
+    VERSION = "1.1.0".freeze
   end
 end

--- a/spec/factories/notifications_client.rb
+++ b/spec/factories/notifications_client.rb
@@ -2,8 +2,8 @@ FactoryGirl.define do
   factory :notifications_client,
           class: Notifications::Client do
     base_url { nil }
-    jwt_service "0af431f4-0336-4cae-5e68-968cb0af431f"
-    jwt_secret "b646da86-2648-a663-ce2b-f26489a663cce2b"
+    jwt_service "fa80e418-ff49-445c-a29b-92c04a181207"
+    jwt_secret "7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
 
     initialize_with do
       new(jwt_service, jwt_secret, base_url)

--- a/spec/factories/notifications_client.rb
+++ b/spec/factories/notifications_client.rb
@@ -10,6 +10,35 @@ FactoryGirl.define do
     end
   end
 
+  factory :notifications_client_combined,
+          class: Notifications::Client do
+    jwt_service "test_key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
+
+    initialize_with do
+      new(jwt_service)
+    end
+  end
+
+  factory :notifications_client_combined_with_base_url,
+          class: Notifications::Client do
+    base_url { "http://example.com" }
+    jwt_service "test_key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
+
+    initialize_with do
+      new(jwt_service, base_url)
+    end
+  end
+
+  factory :notifications_client_service_id_and_new_api_key,
+          class: Notifications::Client do
+    jwt_service "fa80e418-ff49-445c-a29b-92c04a181207"
+    jwt_secret "test_key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
+
+    initialize_with do
+      new(jwt_service, jwt_secret)
+    end
+  end
+
   ##
   # stubbed. response from API
   factory :notifications_client_post_response,

--- a/spec/notifications/client_spec.rb
+++ b/spec/notifications/client_spec.rb
@@ -5,6 +5,79 @@ describe Notifications::Client do
     expect(Notifications::Client::VERSION).not_to be nil
   end
 
+  describe "with combined API key" do
+
+    let(:client) { build :notifications_client_combined }
+
+    it "should extract service ID" do
+      expect(
+        client.service_id
+      ).to eq("fa80e418-ff49-445c-a29b-92c04a181207")
+    end
+
+    it "should extract secret" do
+      expect(
+        client.secret_token
+      ).to eq("7aaec57c-2dc9-4d31-8f5c-7225fe79516a")
+    end
+
+    it "should have use default base URL" do
+      expect(
+        client.base_url
+      ).to eq(Notifications::Client::PRODUCTION_BASE_URL)
+    end
+
+  end
+
+
+  describe "with combined API key and non-default base URL" do
+
+    let(:client) { build :notifications_client_combined_with_base_url }
+
+    it "should extract service ID" do
+      expect(
+        client.service_id
+      ).to eq("fa80e418-ff49-445c-a29b-92c04a181207")
+    end
+
+    it "should extract secret" do
+      expect(
+        client.secret_token
+      ).to eq("7aaec57c-2dc9-4d31-8f5c-7225fe79516a")
+    end
+
+    it "should use custom base URL" do
+      expect(
+        client.base_url
+      ).to eq("http://example.com")
+    end
+
+  end
+
+  describe "with service ID and new style API key" do
+
+    let(:client) { build :notifications_client_service_id_and_new_api_key }
+
+    it "should extract service ID" do
+      expect(
+        client.service_id
+      ).to eq("fa80e418-ff49-445c-a29b-92c04a181207")
+    end
+
+    it "should extract secret" do
+      expect(
+        client.secret_token
+      ).to eq("7aaec57c-2dc9-4d31-8f5c-7225fe79516a")
+    end
+
+    it "should have use default base URL" do
+      expect(
+        client.base_url
+      ).to eq(Notifications::Client::PRODUCTION_BASE_URL)
+    end
+
+  end
+
   describe "#base_url" do
     describe "default base url" do
       let(:client) { build :notifications_client }


### PR DESCRIPTION
In research we’ve seen people mix up the service ID and API key because they’re both 36 character UUIDs. We can’t get rid of the service ID because it’s used to look up the API key.

Instead, we should change API key to be one long string, which contains both the service ID, API key and (optionally) the name of the key. For example:

**API key**
`casework_production-8b3aa916-ec82-434e-b0c5-d5d9b371d6a3-dcdc5083-2fee-4fba-8afd-51f3f4bcb7b0`

This commit changes the client to make the `secret` argument optional. If it’s not passed, they we attempt to extract it from the second argument (service ID) instead.

If a new-style API key is passed with a service ID as well then we just strip out the parts of the key that aren’t the secret.