### PR TITLE
Replace AR delegation with stdlib Forwardable

### DIFF
--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -3,7 +3,7 @@ require "notifications/client/speaker"
 require "notifications/client/notification"
 require "notifications/client/response_notification"
 require "notifications/client/notifications_collection"
-require 'active_support/core_ext/module/delegation'
+require "forwardable"
 
 module Notifications
   class Client
@@ -11,11 +11,8 @@ module Notifications
 
     PRODUCTION_BASE_URL = "https://api.notifications.service.gov.uk".freeze
 
-    delegate :service_id,
-             :secret_token,
-             :base_url,
-             :base_url=,
-             to: :speaker
+    extend Forwardable
+    def_delegators :speaker, :service_id, :secret_token, :base_url, :base_url=
 
     ##
     # @see Notifications::Client::Speaker#initialize

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -1,5 +1,5 @@
 module Notifications
   class Client
-    VERSION = "1.1.0".freeze
+    VERSION = "1.1.1".freeze
   end
 end


### PR DESCRIPTION
There's no need to pull in a (large) external library to do something that's provided by the standard library.

Also, the dependency on Active Support wasn't actually specified in the gemspec, so use failed with sandboxed bundles...