### PR TITLE
Use http proxy for Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test: ## Run tests
 .PHONY: integration-test
 integration-test: ## Run integration tests
 	bundle exec bin/test_client.rb
-	
+
 .PHONY: generate-env-file
 generate-env-file: ## Generate the environment file for running the tests inside a Docker container
 	bin/generate_docker_env.sh
@@ -39,6 +39,11 @@ build-with-docker: prepare-docker-runner-image ## Build inside a Docker containe
 	docker run -i --rm \
 		--name "${DOCKER_CONTAINER_PREFIX}-build" \
 		-v `pwd`:/var/project \
+		-e http_proxy="${HTTP_PROXY}" \
+		-e HTTP_PROXY="${HTTP_PROXY}" \
+		-e https_proxy="${HTTPS_PROXY}" \
+		-e HTTPS_PROXY="${HTTPS_PROXY}" \
+		-e NO_PROXY="${NO_PROXY}" \
 		${DOCKER_BUILDER_IMAGE_NAME} \
 		make build
 
@@ -47,6 +52,11 @@ test-with-docker: prepare-docker-runner-image generate-env-file ## Run tests ins
 	docker run -i --rm \
 		--name "${DOCKER_CONTAINER_PREFIX}-test" \
 		-v `pwd`:/var/project \
+		-e http_proxy="${HTTP_PROXY}" \
+		-e HTTP_PROXY="${HTTP_PROXY}" \
+		-e https_proxy="${HTTPS_PROXY}" \
+		-e HTTPS_PROXY="${HTTPS_PROXY}" \
+		-e NO_PROXY="${NO_PROXY}" \
 		--env-file docker.env \
 		${DOCKER_BUILDER_IMAGE_NAME} \
 		make test
@@ -56,6 +66,11 @@ integration-test-with-docker: prepare-docker-runner-image generate-env-file ## R
 	docker run -i --rm \
 		--name "${DOCKER_CONTAINER_PREFIX}-integration-test" \
 		-v `pwd`:/var/project \
+		-e http_proxy="${HTTP_PROXY}" \
+		-e HTTP_PROXY="${HTTP_PROXY}" \
+		-e https_proxy="${HTTPS_PROXY}" \
+		-e HTTPS_PROXY="${HTTPS_PROXY}" \
+		-e NO_PROXY="${NO_PROXY}" \
 		--env-file docker.env \
 		${DOCKER_BUILDER_IMAGE_NAME} \
 		make integration-test

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,10 @@
 FROM ruby:2.3.1-slim
 
+ARG APT_HTTP_PROXY
+
 RUN \
 	echo "Install Debian packages" \
+	&& ([ -z "$APT_HTTP_PROXY" ] || echo "Acquire::http::Proxy \"${APT_HTTP_PROXY}\";\n" > /etc/apt/apt.conf.d/99HttpProxy) \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		make \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,4 +7,4 @@ help:
 
 .PHONY: build
 build:
-	docker build --pull -t govuk/notify-ruby-client-builder .
+	docker build --pull -t govuk/notify-ruby-client-builder --build-arg APT_HTTP_PROXY="${HTTP_PROXY}" .

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -84,7 +84,7 @@ module Notifications
 
       def open(request)
         uri = URI.parse(@base_url)
-        Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        Net::HTTP.start(uri.host, uri.port, :ENV, use_ssl: uri.scheme == 'https') do |http|
           http.request(request)
         end
       end

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -1,5 +1,5 @@
 module Notifications
   class Client
-    VERSION = "1.1.1".freeze
+    VERSION = "1.1.2".freeze
   end
 end


### PR DESCRIPTION
The HTTP.start is pretty lame, because it is overriding the HTTP.new's p_addr parameter's value with nil, which turns off the http proxy explicitely. BAAAAH.

As I needed to do a small code change, please review.