### PR TITLE
Upgrade to API version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 * `Notifications::Client.get_all_notifications()` => the response object has changed.
   * You can also filter the collection of `Notifications` by `reference`. See the README for more information.
 * `Notifications::Client.get_notification(id)` => the response object has changed. See the README for more information.
+* Initializing a client only requires the api key. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+##2.0.0
+
+###Changed
+* Using version 2 of the notification-api.
+* `Notifications::Client.send_sms()` input parameters and the response object has changed, see the README for more information.
+ ```ruby
+    client.sendSms(phone_number, template_id, personalisation, reference)
+  ```
+* `Notifications::Client.send_email()`  input parameters has changed and the response object, see the README for more information.
+   ```ruby
+      client.sendSms(phone_number, template_id, personalisation, reference)
+    ```
+* `reference` is a new optional argument of the send methods. The `reference` can be used as a unique reference for the notification. Because Notify does not require this reference to be unique you could also use this reference to identify a batch or group of notifications.
+* `Notifications::Client.get_all_notifications()` => the response object has changed.
+  * You can also filter the collection of `Notifications` by `reference`. See the README for more information.
+* `Notifications::Client.get_notification(id)` => the response object has changed. See the README for more information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ###Changed
 * Using version 2 of the notification-api.
+* A new `Notifications::Client` no longer requires the `service_id`, only the `api_key` is required.
 * `Notifications::Client.send_sms()` input parameters and the response object has changed, see the README for more information.
  ```ruby
     client.sendSms(phone_number, template_id, personalisation, reference)
@@ -14,4 +15,4 @@
 * `Notifications::Client.get_all_notifications()` => the response object has changed.
   * You can also filter the collection of `Notifications` by `reference`. See the README for more information.
 * `Notifications::Client.get_notification(id)` => the response object has changed. See the README for more information.
-* Initializing a client only requires the api key. 
+* Initializing a client only requires the api key.

--- a/README.md
+++ b/README.md
@@ -28,43 +28,224 @@ Generate an API key by logging in to GOV.UK Notify [GOV.UK Notify](https://www.n
 Text message:
 
 ```ruby
-sms = client.send_sms(to: number, 
-                      template: template_id,
-                      personalisation: {
-                      name: "name",
-                      year: "2016"
-  }
-)
-
+require 'notifications/client/response_notification'
+sms = client.send_sms(phone_number: number,
+                      template_id: template_id,
+                      personalisation: Hash[name: "name",
+                                        year: "2016",                      
+                                      ],
+                      reference: "your_reference_string"
+                      ) # => Notifications::Client::ResponseNotification
 ```
+
+<details>
+<summary>
+Response
+</summary>
+
+If the request is successful, a `Notifications::Client:ResponseNotification` is returned
+
+```ruby
+sms => Notifications::Client::ResponseNotification
+
+sms.id         # => uuid for the notification
+sms.reference  # => Reference string you supplied in the request
+sms.type       # => sms
+sms.status     # => status of the message "created|pending|sent|delivered|permanent-failure|temporary-failure"
+content        # => Hash containing body => the message sent to the recipient, with placeholders replaced.
+               #                    from_number => the sms sender number of your service found **Settings** page
+template       # => Hash containing id => id of the template
+               #                    version => version of the template
+               #                    uri => url of the template    
+uri            # => URL of the notification
+```
+
+Otherwise the client will raise a `Notifications::Client::RequestError`:
+<table>
+ <thead>
+   <tr>
+    <th>error.code</th>
+    <th>error.message</th>
+   </tr>
+ </thead>
+ <tbody>
+   <tr>
+    <td>
+      <pre>429</pre>
+    </td>
+    <td>
+      <pre>
+      [{
+          "error": "TooManyRequestsError",
+          "message": "Exceeded send limits (50) for today"
+      }]
+      </pre>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <pre>400</pre>
+    </td>
+    <td>
+      <pre>
+      [{
+          "error": "BadRequestError",
+          "message": "Can"t send to this recipient using a team-only API key"
+      ]}
+      </pre>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <pre>400</pre>
+    </td>
+    <td>
+      <pre>
+      [{
+          "error": "BadRequestError",
+          "message": "Can"t send to this recipient when service is in trial mode
+                      - see https://www.notifications.service.gov.uk/trial-mode"
+      }]
+      </pre>
+    </td>
+  </tr>
+</tbody>
+</table>
+</details>                  
+
 
 Email:
+
 ```ruby
-email = client.send_email(
-  to: email_address, 
-  template: template_id,
-  personalisation: {
-    name: "name",
-    year: "2016"
-  }
-) # => Notifications::Client::ResponseNotification
+require 'notifications/client/response_notification'
+email = client.send_email(email_address: email_address,
+                          template: template_id,
+                          personalisation: Hash[name: "name",
+                                            year: "2016"
+                                          ],
+                          reference: "your_reference_string"
+                        ) # => Notifications::Client::ResponseNotification
 ```
 
-Find `template_id` by clicking **API info** for the template you want to send.
+<details>
+<summary>
+Response
+</summary>
 
-If a template has placeholders, you need to provide their values in `personalisation`. Otherwise do not pass in `personalisation`
+If the request is successful, a `Notifications::Client:ResponseNotification` is returned
 
-If successful the response is a `Notifications::Client::ResponseNotification`, which has the notification id.
-Otherwise a Notifications::Client::RequestError is returned.
+```ruby
+email => Notifications::Client::ResponseNotification
 
+email.id         # => uuid for the notification
+email.reference  # => Reference string you supplied in the request
+email.type       # => sms
+email.status     # => status of the message "created|pending|sent|delivered|permanent-failure|temporary-failure"
+email.content    # => Hash containing body => the message sent to the recipient, with placeholders replaced.
+                 #                    subject => subject of the message sent to the recipient, with placeholders replaced.
+                 #                    from_email => the from email of your service found **Settings** page
+email.template   # => Hash containing id => id of the template
+                 #                    version => version of the template
+                 #                    uri => url of the template    
+email.uri        # => URL of the notification
+```
+
+Otherwise the client will raise a `Notifications::Client::RequestError`:
+<table>
+ <thead>
+   <tr>
+    <th>error.code</th>
+    <th>error.message</th>
+   </tr>
+ </thead>
+ <tbody>
+   <tr>
+    <td>
+      <pre>429</pre>
+    </td>
+    <td>
+      <pre>
+      [{
+          "error": "TooManyRequestsError",
+          "message": "Exceeded send limits (50) for today"
+      }]
+      </pre>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <pre>400</pre>
+    </td>
+    <td>
+      <pre>
+      [{
+          "error": "BadRequestError",
+          "message": "Can"t send to this recipient using a team-only API key"
+      ]}
+      </pre>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <pre>400</pre>
+    </td>
+    <td>
+      <pre>
+      [{
+          "error": "BadRequestError",
+          "message": "Can"t send to this recipient when service is in trial mode
+                      - see https://www.notifications.service.gov.uk/trial-mode"
+      }]
+      </pre>
+    </td>
+  </tr>
+</tbody>
+</table>
+</details>
+
+### Arguments
+#### `phone_number`
+The phone number of the recipient, only required for sms notifications.
+
+#### `email_address`
+The email address of the recipient, only required for email notifications.
+
+#### `template_id`
+Find by clicking **API info** for the template you want to send.
+
+#### `reference`
+An optional identifier you generate. The `reference` can be used as a unique reference for the notification. Because Notify does not require this reference to be unique you could also use this reference to identify a batch or group of notifications.
+
+You can omit this argument if you do not require a reference for the notification.
+
+#### `personalisation`
+If the template has placeholders you need to provide their values as a Hash, for example:
+
+```ruby
+  personalisation=Hash[
+                        'first_name': 'Amala',
+                        'reference_number': '300241',
+                      ]
+```
+
+You can omit this argument if the template does not contain placeholders.
 
 ### Get the status of one message
 
 ```ruby
 notification = client.get_notification(id) # => Notifications::Client::Notification
+```
+
+<details>
+<summary>
+Response
+</summary>
+If successful a `Notifications::Client::Notification is returned.
+
+```ruby
 notification.id         # => uuid for the notification
 notification.to         # => recipient email address or mobile number
-notification.status     # => status of the message "created|pending|sent|delivered|permanent-failure|temporary-failure" 
+notification.status     # => status of the message "created|pending|sent|delivered|permanent-failure|temporary-failure"
 notification.created_at # => Date time the message was created
 notification.api_key    # => uuid for the api key (not the actual api key)
 notification.billable_units # => units billable or nil for email
@@ -80,69 +261,134 @@ notification.template_version # Template version number
 notification.reference  # => reference of the email or nil for sms
 notification.updated_at # => Date time that the notification was last updated
 ```
+Otherwise a `Notification::Client::RequestError` is raised
 
+<table>
+<thead>
+<tr>
+<th>`error.code`</th>
+<th>`error.message`</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>404</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+}]
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>400</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "ValidationError",
+    "message": "id is not a valid UUID"
+}]
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</details>
+
+</details>
 ### Get the status of all messages
 
 ```ruby
-notifications = client.get_notifications
-notifications.links # => {"last"=>"/notifications?page=4", "next"=>"/notifications?page=2"}
-notifications.total # => 202
-notifications.page_size # => 50
+args = Hash[
+			'template_type', 'sms',
+            'status', 'failed',
+            'reference', 'your reference string'
+            ]
+notifications = client.get_notifications(args)
+```
+<details>
+<summary>
+Response
+</summary>
+If the request is successful a `Notifications::Client::NotificationsCollection` is returned.
+
+```ruby
+notifications.links # => Hash containing current=>"/notifications?template_type=sms&status=delivered"
+next=>"/notifications?other_than=last_id_in_list&template_type=sms&status=delivered"}
 notifications.collection # => [] (array of notification objects)
-
 ```
-
-Query parameters are also supported
-
-```ruby
-client.get_notifications(
-  page: 2,
-  limit_days: 3,
-  page_size: 20,
-  status: "delivered",
-  template_type: "sms"
-)
-```
-
-### Exceptions
-
-Raised exceptions will contain error message and response status code
-
-```ruby
-client = Notifications::Client.new(base_url, invalid, invalid)
-rescue Notifications::Client::RequestError => e
-e.code # => 403
-e.message # => Invalid credentials
-```
+Otherwise the client will raise a `Notifications::Client::RequestError`:
 <table>
-  <thead>
-    <tr>
-      <td> Code </td>
-      <td> Message </td>
-     </tr>
-  </thead>
-  <tbdoy>
-  <tr>
-    <td> 403 </td>
-    <td> {"token"=>["Invalid token: signature"]} </td>
-  </tr>
-  <tr>
-    <td> 403 </td>
-    <td> {"token"=>["Invalid token: expired"]} </td>
-  </tr>
-  <tr>
-    <td> 429 </td>
-    <td> Exceeded send limits (50) for today </td>
-  </tr>
-  <tr>
-    <td> 400 </td>
-    <td> Can’t send to this recipient using a team-only API key </td>
-  </tr>
-  <tr>
-    <td> 400 </td>
-    <td> Can’t send to this recipient when service is in trial 
-          mode - see https://www.notifications.service.gov.uk/trial-mode
-    </td>
-  </tr>
-  </tbody>
+<thead>
+<tr>
+<th>error.status_code</th>
+<th>error.message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>400</pre>
+</td>
+<td>
+<pre>
+[{
+	'error': 'ValidationError',
+    'message': 'bad status is not one of [created, sending, delivered, pending, failed, technical-failure, temporary-failure, permanent-failure]'
+}]
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>400</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "ValidationError",
+    "message": "Apple is not one of [sms, email, letter]"
+}]
+</pre>
+</td>
+</tr>
+</tbody>
 </table>
+</details>
+
+### Arguments
+Omit the argument Hash if you do not want to filter the results.
+#### `template_type`
+
+You can filter by:
+
+* `email`
+* `sms`
+* `letter`
+
+You can omit this argument to ignore the filter.
+
+#### `status`
+
+You can filter by:
+
+* `sending` - the message is queued to be sent by the provider.
+* `delivered` - the message was successfully delivered.
+* `failed` - this will return all failure statuses `permanent-failure`, `temporary-failure` and `technical-failure`.
+* `permanent-failure` - the provider was unable to deliver message, email or phone number does not exist; remove this recipient from your list.
+* `temporary-failure` - the provider was unable to deliver message, email box was full or the phone was turned off; you can try to send the message again.
+* `technical-failure` - Notify had a technical failure; you can try to send the message again.
+
+You can omit this argument to ignore the filter.
+
+### `reference`
+
+This is the `reference` you gave at the time of sending the notification. The `reference` can be a unique identifier for the notification or an identifier for a batch of notifications.
+
+You can omit this argument to ignore the filter.

--- a/README.md
+++ b/README.md
@@ -305,10 +305,12 @@ Otherwise a `Notification::Client::RequestError` is raised
 ### Get the status of all messages
 
 ```ruby
+# See section below for a description of the arguments.
 args = Hash[
-			'template_type', 'sms',
+            'template_type', 'sms',
             'status', 'failed',
             'reference', 'your reference string'
+            'olderThanId', 'e194efd1-c34d-49c9-9915-e4267e01e92e' # => Notifications::Client::Notification
             ]
 notifications = client.get_notifications(args)
 ```
@@ -392,3 +394,8 @@ You can omit this argument to ignore the filter.
 This is the `reference` you gave at the time of sending the notification. The `reference` can be a unique identifier for the notification or an identifier for a batch of notifications.
 
 You can omit this argument to ignore the filter.
+
+
+#### `olderThanId`
+You can get the notifications older than a given `Notification.id`.
+You can pass an empty string or null to ignore the filter

--- a/README.md
+++ b/README.md
@@ -205,10 +205,10 @@ Otherwise the client will raise a `Notifications::Client::RequestError`:
 
 ### Arguments
 #### `phone_number`
-The phone number of the recipient, only required for sms notifications.
+The phone number of the recipient, only required when using `client.send_sms`.
 
 #### `email_address`
-The email address of the recipient, only required for email notifications.
+The email address of the recipient, only required when using `client.send_email`.
 
 #### `template_id`
 Find by clicking **API info** for the template you want to send.
@@ -398,4 +398,4 @@ You can omit this argument to ignore the filter.
 
 #### `olderThanId`
 You can get the notifications older than a given `Notification.id`.
-You can pass an empty string or null to ignore the filter
+You can omit this argument to ignore this filter.

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -5,7 +5,7 @@ require 'notifications/client/response_notification'
 require 'notifications/client/notification'
 
 def main
-  client = Notifications::Client.new(ENV['SERVICE_ID'], ENV['API_KEY'], ENV['NOTIFY_API_URL'])
+  client = Notifications::Client.new(ENV['API_KEY'], ENV['NOTIFY_API_URL'])
   email_notification = test_send_email_endpoint(client)
   sms_notification = test_send_sms_endpoint(client)
   test_get_notification_by_id_endpoint(client, email_notification.id, 'email')

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -16,15 +16,17 @@ def main
 end
 
 def test_send_email_endpoint(client)
-  email_resp = client.send_email(to: ENV['FUNCTIONAL_TEST_EMAIL'], template: ENV['EMAIL_TEMPLATE_ID'],
-                                 personalisation:Hash["name", "some name"])
+  email_resp = client.send_email(email_address: ENV['FUNCTIONAL_TEST_EMAIL'], template_id: ENV['EMAIL_TEMPLATE_ID'],
+                                 personalisation:Hash["name", "some name"],
+                                 reference: "some reference")
   test_notification_response_data_type(email_resp, 'email')
   email_resp
 end
 
 def test_send_sms_endpoint(client)
-  sms_resp = client.send_sms(to: ENV['FUNCTIONAL_TEST_NUMBER'], template: ENV['SMS_TEMPLATE_ID'],
-                             personalisation:Hash["name", "some name"])
+  sms_resp = client.send_sms(phone_number: ENV['FUNCTIONAL_TEST_NUMBER'], template_id: ENV['SMS_TEMPLATE_ID'],
+                             personalisation:Hash["name", "some name"],
+                             reference: "some reference")
   test_notification_response_data_type(sms_resp, 'sms')
   sms_resp
 end
@@ -106,49 +108,50 @@ end
 
 def expected_fields_in_email_resp
   %w(id
-     api_key
-     billable_units
-     to
-     subject
-     body
-     notification_type
+     reference
+     email_address
+     type
      status
-     service
      sent_at
-     sent_by
      template
-     template_version
      created_at
-     updated_at
 )
 end
 
 def expected_fields_in_email_resp_that_are_nil
-  %w(job)
+  %w(phone_number
+     line_1
+     line_2
+     line_3
+     line_4
+     line_5
+     line_5
+     line_6
+     postcode
+     )
 end
 
 def expected_fields_in_sms_resp
   %w(id
-   api_key
-   billable_units
-   to
-   body
-   notification_type
-   status
-   service
-   sent_at
-   sent_by
-   template
-   template_version
-   created_at
-   updated_at
+     phone_number
+     type
+     status
+     sent_at
+     template
+     created_at
    )
 end
 
 def expected_fields_in_sms_resp_that_are_nil
-  %w(job
-  subject
-	reference)
+  %w(email_address
+     line_1
+     line_2
+     line_3
+     line_4
+     line_5
+     line_5
+     line_6
+     postcode)
 end
 
 def test_get_all_notifications(client, first_id, second_id)
@@ -173,8 +176,6 @@ end
 
 def expected_fields_for_get_all_notifications
   %W(links
-	total
-	page_size
 	collection
 	)
 end

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -114,6 +114,8 @@ def expected_fields_in_email_resp
      status
      sent_at
      template
+     body
+     subject
      created_at
 )
 end
@@ -138,6 +140,7 @@ def expected_fields_in_sms_resp
      status
      sent_at
      template
+     body
      created_at
    )
 end
@@ -151,7 +154,8 @@ def expected_fields_in_sms_resp_that_are_nil
      line_5
      line_5
      line_6
-     postcode)
+     postcode
+     subject)
 end
 
 def test_get_all_notifications(client, first_id, second_id)

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -57,6 +57,8 @@ module Notifications
     #   temporarily failed, or technical failure
     # @option options [String] :reference
     #   your reference for the notification
+    # @option options [String] :olderThanId
+    #   notification id to return notificaitons that are older than this id.
     # @see Notifications::Client::Speaker#get
     # @return [NotificationsCollection]
     def get_notifications(options = {})

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -55,9 +55,8 @@ module Notifications
     # @option options [String] :status
     #   sending, delivered, permanently failed,
     #   temporarily failed, or technical failure
-    # @option options [String] :page
-    # @option options [String] :page_size
-    # @option options [String] :limit_days
+    # @option options [String] :reference
+    #   your reference for the notification
     # @see Notifications::Client::Speaker#get
     # @return [NotificationsCollection]
     def get_notifications(options = {})

--- a/lib/notifications/client/notification.rb
+++ b/lib/notifications/client/notification.rb
@@ -16,6 +16,8 @@ module Notifications
         :type,
         :status,
         :template,
+        :body,
+        :subject,
         :sent_at,
         :created_at,
         :completed_at

--- a/lib/notifications/client/notification.rb
+++ b/lib/notifications/client/notification.rb
@@ -3,28 +3,27 @@ module Notifications
     class Notification
       FIELDS = [
         :id,
-        :api_key,
-        :billable_units,
-        :to,
-        :subject,
-        :body,
-        :job,
-        :notification_type,
-        :status,
-        :service,
-        :sent_at,
-        :sent_by,
-        :template,
-        :template_version,
         :reference,
+        :email_address,
+        :phone_number,
+        :line_1,
+        :line_2,
+        :line_3,
+        :line_4,
+        :line_5,
+        :line_6,
+        :postcode,
+        :type,
+        :status,
+        :template,
+        :sent_at,
         :created_at,
-        :updated_at
+        :completed_at
       ].freeze
 
       attr_reader(*FIELDS)
 
       def initialize(notification)
-        notification = normalize(notification)
 
         FIELDS.each do |field|
             instance_variable_set(:"@#{field}", notification.fetch(field.to_s, nil)
@@ -35,7 +34,7 @@ module Notifications
       [
         :sent_at,
         :created_at,
-        :updated_at
+        :completed_at
       ].each do |field|
         define_method field do
           begin
@@ -47,11 +46,6 @@ module Notifications
         end
       end
 
-      private
-
-      def normalize(notification)
-        notification.key?('data') ? notification['data']['notification'] : notification
-      end
     end
   end
 end

--- a/lib/notifications/client/notifications_collection.rb
+++ b/lib/notifications/client/notifications_collection.rb
@@ -2,14 +2,10 @@ module Notifications
   class Client
     class NotificationsCollection
       attr_reader :links,
-                  :total,
-                  :page_size,
                   :collection
 
       def initialize(response)
         @links = response["links"]
-        @total = response["total"]
-        @page_size = response["page_size"]
         @collection = collection_from(response["notifications"])
       end
 

--- a/lib/notifications/client/request_error.rb
+++ b/lib/notifications/client/request_error.rb
@@ -13,7 +13,7 @@ module Notifications
       end
 
       def message_from(body)
-        JSON.parse(body).fetch("message")
+        JSON.parse(body).fetch('errors')
       rescue JSON::ParserError
         body
       end

--- a/lib/notifications/client/response_notification.rb
+++ b/lib/notifications/client/response_notification.rb
@@ -4,8 +4,6 @@ module Notifications
       FIELDS = [
       :id,
       :reference,
-      :type,
-      :status,
       :content,
       :template,
       :uri

--- a/lib/notifications/client/response_notification.rb
+++ b/lib/notifications/client/response_notification.rb
@@ -1,11 +1,27 @@
 module Notifications
   class Client
     class ResponseNotification
-      attr_reader :id
+      FIELDS = [
+      :id,
+      :reference,
+      :type,
+      :status,
+      :content,
+      :template,
+      :uri
+    ].freeze
 
-      def initialize(response)
-        @id = response["data"]["notification"]["id"]
+
+      attr_reader(*FIELDS)
+
+      def initialize(notification)
+
+        FIELDS.each do |field|
+            instance_variable_set(:"@#{field}", notification.fetch(field.to_s, nil)
+            )
+        end
       end
+
     end
   end
 end

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -14,26 +14,13 @@ module Notifications
       USER_AGENT = "NOTIFY-API-RUBY-CLIENT/#{Notifications::Client::VERSION}".freeze
 
       ##
-      # @param service_id [String] your service
-      #   API identifier
-      # @param secret [String] your service API
-      #   secret
-      # @param base_url [String] host URL. This is
-      #   the address to perform the requests
-      def initialize(service_id, secret_token = nil, base_url = nil)
-        if secret_token == nil and base_url == nil
-          @service_id = service_id[service_id.length - 73..service_id.length - 38]
-          @secret_token = service_id[service_id.length - 36..service_id.length]
-          @base_url = PRODUCTION_BASE_URL
-        elsif secret_token.start_with?("http") and base_url == nil
-          @service_id = service_id[service_id.length - 73..service_id.length - 38]
-          @secret_token = service_id[service_id.length - 36..service_id.length]
-          @base_url = secret_token
-        else
-          @service_id = service_id
-          @secret_token = secret_token[secret_token.length - 36..secret_token.length]
-          @base_url = base_url || PRODUCTION_BASE_URL
-        end
+      # @param secret [String] your service API secret
+      # @param base_url [String] host URL. This is the address to perform the requests.
+      #                          If left nil the production url is used.
+      def initialize(secret_token = nil, base_url = nil)
+        @service_id = secret_token[secret_token.length - 73..secret_token.length - 38]
+        @secret_token = secret_token[secret_token.length - 36..secret_token.length]
+        @base_url = base_url || PRODUCTION_BASE_URL
       end
 
       ##

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -10,7 +10,7 @@ module Notifications
       attr_reader :service_id
       attr_reader :secret_token
 
-      BASE_PATH = "/notifications".freeze
+      BASE_PATH = "/v2/notifications".freeze
       USER_AGENT = "NOTIFY-API-RUBY-CLIENT/#{Notifications::Client::VERSION}".freeze
 
       ##
@@ -39,12 +39,18 @@ module Notifications
       ##
       # @param kind [String] 'email' or 'sms'
       # @param form_data [Hash]
-      # @option form_data [String] :to recipient
-      #   to notify (sms or email)
+      # @option form_data [String] :phone_number
+      #   phone number of the sms recipient
+      # @option form_data [String] :email_address
+      #   email address of the email recipent
       # @option form_data [String] :template
       #   template to render in notification
       # @option form_data [Hash] :personalisation
       #   fields to use in the template
+      # @option form_data [String] :reference
+      #   A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
+      #   This reference can be unique or used used to refer to a batch of notifications.
+      #   Can be an empty string or nil, when you do not require a reference for the notifications.
       # @see #perform_request!
       def post(kind, form_data)
         request = Net::HTTP::Post.new(

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -1,5 +1,5 @@
 module Notifications
   class Client
-    VERSION = "1.1.2".freeze
+    VERSION = "2.0.0".freeze
   end
 end

--- a/notifications-ruby-client.gemspec
+++ b/notifications-ruby-client.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
     "dazahern"
   ]
 
-  spec.email         = ["info@bitzesty.com", "daz.ahern@digital.cabinet-office.gov.uk"]
+  spec.email         = ["notify@digital.cabinet-office.gov.uk"]
 
   spec.summary       = "Ruby client for GOV.UK Notifications API"
   spec.homepage      = "https://github.com/alphagov/notifications-ruby-client"

--- a/notifications-ruby-client.gemspec
+++ b/notifications-ruby-client.gemspec
@@ -7,8 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = "notifications-ruby-client"
   spec.version       = Notifications::Client::VERSION
   spec.authors       = [
-    "bitzesty",
-    "dazahern"
+    "Government Digital Service"
   ]
 
   spec.email         = ["notify@digital.cabinet-office.gov.uk"]

--- a/spec/factories/client_notifications.rb
+++ b/spec/factories/client_notifications.rb
@@ -7,34 +7,28 @@ FactoryGirl.define do
 
     body do
       {
-        "data" => {
-          "notification" => {
-            "status" => "delivered",
-            "to" => "07515 987 456",
-            "template" => {
+        "id" => "f163deaf-2d3f-4ec6-98fc-f23fa511518f",
+        "reference" => "your_reference_string",
+        "phone_number" => "07515 987 456",
+        "email_address" => nil,
+        "line_1" => nil,
+        "line_2" => nil,
+        "line_3" => nil,
+        "line_4" => nil,
+        "line_5" => nil,
+        "line_6" => nil,
+        "postcode" => nil,
+        "type" => "sms",
+        "status" => "delivered",
+        "template" =>
+            {
               "id" => "5e427b42-4e98-46f3-a047-32c4a87d26bb",
-              "name" => "First template",
-              "template_type" => "sms"
+              "uri" => "/v2/templates/5e427b42-4e98-46f3-a047-32c4a87d26bb",
+              "version" => 1
             },
-            "created_at" => "2016-04-26T15:29:36.891512+00:00",
-            "updated_at" => "2016-04-26T15:29:38.724808+00:00",
-            "sent_at" => "2016-04-26T15:29:37.230976+00:00",
-            "job" => {
-              "id" => "f9043884-acac-46db-b2ea-f08cd8ec6d67",
-              "original_file_name" => "Test run"
-            },
-            "id" => "f163deaf-2d3f-4ec6-98fc-f23fa511518f",
-            "service" => "5cf87313-fddd-4482-a2ea-48e37320efd1",
-            "reference" => "None",
-            "sent_by" => "mmg",
-            "api_key" => "Test API key",
-            "billable_units" => 0,
-            "body" => "Test body",
-            "notification_type" => "email",
-            "subject" => "Test subject",
-            "template_version" => 10
-          }
-        }
+        "created_at" => "2016-11-29T11:12:30.12354Z",
+        "sent_at" => "2016-11-29T11:12:40.12354Z",
+        "completed_at" => "2016-11-29T11:12:52.12354Z"
       }
     end
   end

--- a/spec/factories/client_notifications.rb
+++ b/spec/factories/client_notifications.rb
@@ -26,6 +26,8 @@ FactoryGirl.define do
               "uri" => "/v2/templates/5e427b42-4e98-46f3-a047-32c4a87d26bb",
               "version" => 1
             },
+        "body" => "Body of the message",
+        "subject" => nil,
         "created_at" => "2016-11-29T11:12:30.12354Z",
         "sent_at" => "2016-11-29T11:12:40.12354Z",
         "completed_at" => "2016-11-29T11:12:52.12354Z"

--- a/spec/factories/client_notifications_collections.rb
+++ b/spec/factories/client_notifications_collections.rb
@@ -7,14 +7,12 @@ FactoryGirl.define do
 
     body do
       {
-        "total" => 162,
-        "page_size" => 50,
         "links" => {
-          "last" => "/notifications?page=3&template_type=sms&status=delivered",
-          "next" => "/notifications?page=3&template_type=sms&status=delivered"
+          "current" => "/v2/notifications?page=3&template_type=sms&status=delivered",
+          "next" => "/v2/notifications?page=3&template_type=sms&status=delivered"
         },
         "notifications" => 2.times.map {
-          attributes_for(:client_notification)[:body]["data"]["notification"]
+          attributes_for(:client_notification)[:body]
         }
       }
     end

--- a/spec/factories/client_request_errors.rb
+++ b/spec/factories/client_request_errors.rb
@@ -1,11 +1,12 @@
 FactoryGirl.define do
   factory :client_request_error,
           class: Notifications::Client::RequestError do
-    code "403"
+    code '403'
     body do
       {
-        "result" => "error",
-        "message" => "Invalid token: expired"
+          'status_code' => 400,
+          'errors' => ['error' => 'BadRequest',
+                      'message' => 'Invalid token: expired']
       }
     end
 

--- a/spec/factories/notifications_client.rb
+++ b/spec/factories/notifications_client.rb
@@ -41,15 +41,45 @@ FactoryGirl.define do
 
   ##
   # stubbed. response from API
-  factory :notifications_client_post_response,
+  factory :notifications_client_post_sms_response,
           class: Notifications::Client::ResponseNotification do
     body do
       {
-        "data" => {
-          "notification" => {
-            "id" => 1
-          }
-        }
+        "id" => "aceed36e-6aee-494c-a09f-88b68904bad6",
+        "reference" => nil,
+        "content" => {"body" => "Hello we got your application",
+                      "from_number" => "40604"
+                    },
+        "template" => {"id" => "f6895ff7-86e0-4d38-80ab-c9525856c3ff",
+                       "version" => 1,
+                       "uri" => "/v2/templates/f6895ff7-86e0-4d38-80ab-c9525856c3ff"
+                     },
+        "uri" => "/notifications/aceed36e-6aee-494c-a09f-88b68904bad6"
+      }
+    end
+
+    initialize_with do
+      new(body)
+    end
+  end
+
+  ##
+  # stubbed. response from API
+  factory :notifications_client_post_email_response,
+          class: Notifications::Client::ResponseNotification do
+    body do
+      {
+        "id" => "aceed36e-6aee-494c-a09f-88b68904bad6",
+        "reference" => nil,
+        "content" => {"body" => "Hello we got your application",
+                      "subject" => "Application recieved",
+                      "from_email" => "40604"
+                    },
+        "template" => {"id" => "f6895ff7-86e0-4d38-80ab-c9525856c3ff",
+                       "version" => 1,
+                       "uri" => "/v2/templates/f6895ff7-86e0-4d38-80ab-c9525856c3ff"
+                     },
+        "uri" => "/notifications/aceed36e-6aee-494c-a09f-88b68904bad6"
       }
     end
 

--- a/spec/factories/notifications_client.rb
+++ b/spec/factories/notifications_client.rb
@@ -2,11 +2,10 @@ FactoryGirl.define do
   factory :notifications_client,
           class: Notifications::Client do
     base_url { nil }
-    jwt_service "fa80e418-ff49-445c-a29b-92c04a181207"
-    jwt_secret "7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
+    jwt_secret "test-key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
 
     initialize_with do
-      new(jwt_service, jwt_secret, base_url)
+      new(jwt_secret, base_url)
     end
   end
 
@@ -26,16 +25,6 @@ FactoryGirl.define do
 
     initialize_with do
       new(jwt_service, base_url)
-    end
-  end
-
-  factory :notifications_client_service_id_and_new_api_key,
-          class: Notifications::Client do
-    jwt_service "fa80e418-ff49-445c-a29b-92c04a181207"
-    jwt_secret "test_key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
-
-    initialize_with do
-      new(jwt_service, jwt_secret)
     end
   end
 

--- a/spec/notifications/client/email_notification_spec.rb
+++ b/spec/notifications/client/email_notification_spec.rb
@@ -3,13 +3,13 @@ require "spec_helper"
 describe Notifications::Client do
   let(:client) { build :notifications_client }
 
-  include_examples "stub_post_request", "email"
+  include_examples "stub_post_email_request", "email"
 
   describe "#send_email" do
     let!(:sent_email) {
       client.send_email(
-        to: "email@gov.uk",
-        template: "f6895ff7-86e0-4d38-80ab-c9525856c3ff"
+        email_address: "email@gov.uk",
+        template_id: "f6895ff7-86e0-4d38-80ab-c9525856c3ff"
       )
     }
 
@@ -18,11 +18,17 @@ describe Notifications::Client do
         Notifications::Client::ResponseNotification
       )
     end
-
-    it "response includes id" do
-      expect(sent_email.id).to eq(
-        mocked_response["data"]["notification"]["id"]
-      )
-    end
+    %w(
+      id
+      content
+      uri
+      template
+    ).each do |field|
+      it "expect to include #{field}" do
+        expect(
+          sent_email.send(field)
+        ).to_not be_nil
+      end
+  end
   end
 end

--- a/spec/notifications/client/get_notification_spec.rb
+++ b/spec/notifications/client/get_notification_spec.rb
@@ -23,7 +23,7 @@ describe Notifications::Client do
     before do
       stub_request(
         :get,
-        "https://#{uri.host}:#{uri.port}/notifications/#{id}"
+        "https://#{uri.host}:#{uri.port}/v2/notifications/#{id}"
       ).to_return(body: mocked_response.to_json)
     end
 
@@ -35,9 +35,14 @@ describe Notifications::Client do
 
     %w(
       id
-      to
+      reference
+      phone_number
+      type
       status
+      template
       created_at
+      sent_at
+      completed_at
     ).each do |field|
       it "expect to include #{field}" do
         expect(

--- a/spec/notifications/client/get_notification_spec.rb
+++ b/spec/notifications/client/get_notification_spec.rb
@@ -40,6 +40,7 @@ describe Notifications::Client do
       type
       status
       template
+      body
       created_at
       sent_at
       completed_at

--- a/spec/notifications/client/get_notifications_spec.rb
+++ b/spec/notifications/client/get_notifications_spec.rb
@@ -19,7 +19,7 @@ describe Notifications::Client do
     before do
       stub_request(
         :get,
-        "https://#{uri.host}:#{uri.port}/notifications"
+        "https://#{uri.host}:#{uri.port}/v2/notifications"
       ).to_return(body: mocked_response.to_json)
     end
 
@@ -39,9 +39,6 @@ describe Notifications::Client do
   describe "get notifications by query" do
     let(:options) {
       {
-        "page"          => 2,
-        "limit_days"    => 3,
-        "page_size"     => 20,
         "template_type" => "sms",
         "status"        => "delivered"
       }
@@ -66,7 +63,7 @@ describe Notifications::Client do
     before do
       stub_request(
         :get,
-        "https://#{uri.host}:#{uri.port}/notifications?#{request_path}"
+        "https://#{uri.host}:#{uri.port}/v2/notifications?#{request_path}"
       ).to_return(body: mocked_response.to_json)
     end
 
@@ -74,7 +71,7 @@ describe Notifications::Client do
       notifications
       expect(WebMock).to have_requested(
         :get,
-        "https://#{uri.host}:#{uri.port}/notifications"
+        "https://#{uri.host}:#{uri.port}/v2/notifications"
       ).with(query: options)
     end
 
@@ -84,7 +81,7 @@ describe Notifications::Client do
       )
     end
 
-    %w(links total page_size).each do |field|
+    %w(links).each do |field|
       it "should contain service #{field}" do
         expect(
           notifications.send(field)

--- a/spec/notifications/client/request_errors_spec.rb
+++ b/spec/notifications/client/request_errors_spec.rb
@@ -15,7 +15,7 @@ describe Notifications::Client do
     before do
       stub_request(
         :get,
-        "https://#{uri.host}:#{uri.port}/notifications/1"
+        "https://#{uri.host}:#{uri.port}/v2/notifications/1"
       ).to_return(
         status: 403,
         body: error_response.to_json

--- a/spec/notifications/client/sms_notification_spec.rb
+++ b/spec/notifications/client/sms_notification_spec.rb
@@ -3,12 +3,12 @@ require "spec_helper"
 describe Notifications::Client do
   let(:client) { build :notifications_client }
 
-  include_examples "stub_post_request", "sms"
+  include_examples "stub_post_sms_request", "sms"
 
   describe "#send_sms" do
     let!(:sent_sms) {
       client.send_sms(
-        to: "+44 7700 900 404",
+        phone_number: "+44 7700 900 404",
         template: "f6895ff7-86e0-4d38-80ab-c9525856c3ff"
       )
     }
@@ -18,11 +18,17 @@ describe Notifications::Client do
         Notifications::Client::ResponseNotification
       )
     end
-
-    it "response includes id" do
-      expect(sent_sms.id).to eq(
-        mocked_response["data"]["notification"]["id"]
-      )
+      %w(
+        id
+        content
+        uri
+        template
+      ).each do |field|
+        it "expect to include #{field}" do
+          expect(
+            sent_sms.send(field)
+          ).to_not be_nil
+        end
     end
   end
 end

--- a/spec/notifications/client/speaker_spec.rb
+++ b/spec/notifications/client/speaker_spec.rb
@@ -7,17 +7,14 @@ describe Notifications::Client do
     let(:jwt_token) {
       client.speaker.send(:jwt_token)
     }
-    let(:jwt_secret) {
-      attributes_for(:notifications_client)[:jwt_secret]
-    }
-    let(:jwt_service) {
-      attributes_for(:notifications_client)[:jwt_service]
-    }
+    let(:secret) { secret = "7aaec57c-2dc9-4d31-8f5c-7225fe79516a" }
+    let(:service_id) { service_id = "fa80e418-ff49-445c-a29b-92c04a181207" }
+
 
     let(:decoded_payload) {
       JWT.decode(
         jwt_token,
-        jwt_secret,
+        secret,
         true,
         algorithm: "HS256"
       )
@@ -26,7 +23,7 @@ describe Notifications::Client do
     it "should have valid payload" do
       expect(
         decoded_payload.first["iss"]
-      ).to eq(jwt_service)
+      ).to eq(service_id)
     end
   end
 end

--- a/spec/notifications/client_spec.rb
+++ b/spec/notifications/client_spec.rb
@@ -54,30 +54,6 @@ describe Notifications::Client do
 
   end
 
-  describe "with service ID and new style API key" do
-
-    let(:client) { build :notifications_client_service_id_and_new_api_key }
-
-    it "should extract service ID" do
-      expect(
-        client.service_id
-      ).to eq("fa80e418-ff49-445c-a29b-92c04a181207")
-    end
-
-    it "should extract secret" do
-      expect(
-        client.secret_token
-      ).to eq("7aaec57c-2dc9-4d31-8f5c-7225fe79516a")
-    end
-
-    it "should have use default base URL" do
-      expect(
-        client.base_url
-      ).to eq(Notifications::Client::PRODUCTION_BASE_URL)
-    end
-
-  end
-
   describe "#base_url" do
     describe "default base url" do
       let(:client) { build :notifications_client }

--- a/spec/support/stub_post_request.rb
+++ b/spec/support/stub_post_request.rb
@@ -1,14 +1,32 @@
-RSpec.shared_examples "stub_post_request" do |kind|
+RSpec.shared_examples "stub_post_email_request" do |kind|
   let(:uri) {
     URI.parse(Notifications::Client::PRODUCTION_BASE_URL)
   }
   let(:mocked_response) {
-    attributes_for(:notifications_client_post_response)[:body]
+    attributes_for(:notifications_client_post_email_response)[:body]
   }
   before do
     stub_request(
       :post,
-      "https://#{uri.host}:#{uri.port}/notifications/#{kind}"
+      "https://#{uri.host}:#{uri.port}/v2/notifications/#{kind}"
+    ).to_return(
+      body: mocked_response.to_json,
+      status: 201,
+      headers: { "Content-Type" => "application/json" }
+    )
+  end
+end
+RSpec.shared_examples "stub_post_sms_request" do |kind|
+  let(:uri) {
+    URI.parse(Notifications::Client::PRODUCTION_BASE_URL)
+  }
+  let(:mocked_response) {
+    attributes_for(:notifications_client_post_sms_response)[:body]
+  }
+  before do
+    stub_request(
+      :post,
+      "https://#{uri.host}:#{uri.port}/v2/notifications/#{kind}"
     ).to_return(
       body: mocked_response.to_json,
       status: 201,


### PR DESCRIPTION
Upgrade to use version 2 of the notification APIs
- change to ResponseNotificationm response to .
- change to Notification, response to getNotificaitonById()
- change to NotificationList, response to getNotifications()
- New filters for getNotifications(status, notificationType, reference, olderThanId)
- Update the README to reflect all these changes.
Now at version 2.0.0