### PR TITLE
Add template methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+##2.1.0
+
+###Changed
+* Added methods to get templates and generate a preview of a template.
+* `get_template_by_id` - get the latest version of a template by id.
+* `get_template_version` - get the template by id and version.
+* `get_all_templates` - get all templates, can be filtered by template type.
+* `generate_template_preview` - get the contents of a template with the placeholders replaced with the given personalisation.
+* See the README for more information about the new template methods.
+
+
 ##2.0.0
 
 ###Changed

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ The template id is visible on the template page in the application.
 This will return the template for the given id and version.
 
 ```ruby
-Template template = client.get_template_version(template_id, version)
+Template template = client.get_template_version(template_id template_id, version)
 ```
 
 <details>
@@ -568,3 +568,69 @@ You can filter the templates by the following options:
 * `sms`
 * `letter`
 You can omit this argument to ignore this filter.
+
+
+## Generate a preview template
+This will return the contents of a template with the placeholders replaced with the given personalisation.
+```ruby
+templatePreview = client.generate_template_preview(template_id: template_id,
+                                                  personalisation: {
+                                                      name: "name",
+                                                      year: "2016",                      
+                                                    })
+```
+
+<details>
+<summary>
+Response
+</summary>
+
+
+```Ruby
+template.id         # => uuid for the template
+template.version    # => version of the template
+template.body       # => content of the template
+template.subject    # => subject for email templates, will be empty for other template types
+```
+
+
+Otherwise a `Notifications::Client::RequestError` is thrown.
+<table>
+<thead>
+<tr>
+<th>message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>
+Status code: 404 {
+"errors":
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+}]
+}
+</pre>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "ValidationError",
+    "message": "id is not a valid UUID"
+}]
+}
+</pre>
+</tbody>
+</table>
+
+</details>
+
+### Arguments
+
+#### `templateId`
+The template id is visible on the template page in the application.
+
+#### `personalisation`
+If a template has placeholders, you need to provide their values. `personalisation` can be an empty or null in which case no placeholders are provided for the notification.

--- a/README.md
+++ b/README.md
@@ -404,3 +404,65 @@ You can omit this argument to ignore the filter.
 #### `olderThanId`
 You can get the notifications older than a given `Notification.id`.
 You can omit this argument to ignore this filter.
+
+
+## Get a template by ID
+This will return the latest version of the template. Use [getTemplateVersion](#get-a-template-by-id-and-version) to retrieve a specific template version.
+
+```ruby
+template = client.get_template_by_id(template_id);
+```
+
+<details>
+<summary>
+Response
+</summary>
+
+```Ruby
+template.id         # => uuid for the template
+template.type       # => type of template one of email|sms|letter
+template.created_at # => date and time the template was created
+template.updated_at # => date and time the template was last updated, may be null if version 1
+template.created_by # => email address of the person that created the template
+template.version    # => version of the template
+template.body       # => content of the template
+template.subject    # => subject for email templates, will be empty for other template types
+```
+
+Otherwise the client will raise a `Notifications::Client::RequestError`.
+
+<table>
+<thead>
+<tr>
+<th>message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>
+Status code: 404 {
+"errors":
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+}]
+}
+</pre>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "ValidationError",
+    "message": "id is not a valid UUID"
+}]
+}
+</pre>
+</tbody>
+</table>
+</details>
+
+### Arguments
+
+#### `templateId`
+The template id is visible on the template page in the application.

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ You can omit this argument to ignore this filter.
 This will return the latest version of the template. Use [getTemplateVersion](#get-a-template-by-id-and-version) to retrieve a specific template version.
 
 ```ruby
-template = client.get_template_by_id(template_id);
+template = client.get_template_by_id(template_id)
 ```
 
 <details>
@@ -466,3 +466,105 @@ Status code: 400 {
 
 #### `templateId`
 The template id is visible on the template page in the application.
+
+
+## Get a template by ID and version
+This will return the template for the given id and version.
+
+```ruby
+Template template = client.get_template_version(template_id, version)
+```
+
+<details>
+<summary>
+Response
+</summary>
+
+```Ruby
+template.id         # => uuid for the template
+template.type       # => type of template one of email|sms|letter
+template.created_at # => date and time the template was created
+template.updated_at # => date and time the template was last updated, may be null if version 1
+template.created_by # => email address of the person that created the template
+template.version    # => version of the template
+template.body       # => content of the template
+template.subject    # => subject for email templates, will be empty for other template types
+```
+
+Otherwise the client will raise a `Notifications::Client::RequestError`.
+
+<table>
+<thead>
+<tr>
+<th>message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>
+Status code: 404 {
+"errors":
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+}]
+}
+</pre>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "ValidationError",
+    "message": "id is not a valid UUID"
+}]
+}
+</pre>
+</tbody>
+</table>
+</details>
+
+### Arguments
+
+#### `templateId`
+The template id is visible on the template page in the application.
+
+#### `version`
+A history of the template is kept. There is a link to `See previous versions` on the template page in the application.
+
+## Get all templates
+This will return the latest version of each template for your service.
+
+```ruby
+args = {
+  'template_type' => 'sms'
+}
+templates = client.get_all_templates(args)
+```
+
+<details>
+<summary>
+Response
+</summary>
+
+```ruby
+    TemplateCollection templates;
+```
+If the response is successful, a TemplateCollection is returned.
+
+If no templates exist for a template type or there no templates for a service, the templates list will be empty.
+
+Otherwise the client will raise a `Notifications::Client::RequestError`.
+
+
+</details>
+
+### Arguments
+
+#### `templateType`
+You can filter the templates by the following options:
+
+* `email`
+* `sms`
+* `letter`
+You can omit this argument to ignore this filter.

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -3,16 +3,37 @@ require 'notifications/client'
 require 'notifications/client/notification'
 require 'notifications/client/response_notification'
 require 'notifications/client/notification'
+require 'notifications/client/response_template'
 
 def main
   client = Notifications::Client.new(ENV['API_KEY'], ENV['NOTIFY_API_URL'])
-  email_notification = test_send_email_endpoint(client)
-  sms_notification = test_send_sms_endpoint(client)
-  test_get_notification_by_id_endpoint(client, email_notification.id, 'email')
-  test_get_notification_by_id_endpoint(client, sms_notification.id, 'sms')
-  test_get_all_notifications(client)
+  test_get_template_by_id(client, ENV['EMAIL_TEMPLATE_ID'])
+  # email_notification = test_send_email_endpoint(client)
+  # sms_notification = test_send_sms_endpoint(client)
+  # test_get_notification_by_id_endpoint(client, email_notification.id, 'email')
+  # test_get_notification_by_id_endpoint(client, sms_notification.id, 'sms')
+  # test_get_all_notifications(client)
   p 'ruby client integration tests pass'
   exit 0
+end
+
+def test_get_template_by_id(client, id)
+  response = client.get_template_by_id(id)
+  p response
+
+  test_template_response(response)
+end
+
+def test_template_response(response)
+  unless response.is_a?(Notifications::Client::Template) then
+    p 'failed test_get_template_by_id response is not a Notifications::Client::Template'
+    exit 1
+  end
+  unless response.id.is_a?(String) then
+    p 'failed template id is not a String'
+    exit 1
+  end
+  field_should_not_be_nil(expected_fields_in_template_response, response, 'get_template_by_id')
 end
 
 def test_send_email_endpoint(client)
@@ -99,6 +120,15 @@ def field_should_be_nil(fields, obj, method_name)
   end
 end
 
+def expected_fields_in_template_response
+  %w(id
+     type
+     created_at
+     created_by
+     body
+     version
+)
+end
 
 def expected_fields_in_notification_response
   %w(id

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -12,23 +12,24 @@ def main
   test_get_template_version(client, ENV['SMS_TEMPLATE_ID'], 1)
   test_get_all_templates(client)
   test_get_all_templates_filter_by_type(client)
-  # email_notification = test_send_email_endpoint(client)
-  # sms_notification = test_send_sms_endpoint(client)
-  # test_get_notification_by_id_endpoint(client, email_notification.id, 'email')
-  # test_get_notification_by_id_endpoint(client, sms_notification.id, 'sms')
-  # test_get_all_notifications(client)
+  test_generate_template_preview(client, ENV['EMAIL_TEMPLATE_ID'])
+  email_notification = test_send_email_endpoint(client)
+  sms_notification = test_send_sms_endpoint(client)
+  test_get_notification_by_id_endpoint(client, email_notification.id, 'email')
+  test_get_notification_by_id_endpoint(client, sms_notification.id, 'sms')
+  test_get_all_notifications(client)
   p 'ruby client integration tests pass'
   exit 0
 end
 
 def test_get_template_by_id(client, id)
   response = client.get_template_by_id(id)
-  test_template_response(response)
+  test_template_response(response, 'test_get_template_by_id')
 end
 
 def test_get_template_version(client, id, version)
   response = client.get_template_version(id, version)
-  test_template_response(response)
+  test_template_response(response, 'test_get_template_version')
 end
 
 def test_get_all_templates(client)
@@ -41,8 +42,8 @@ def test_get_all_templates(client)
     p 'failed test_get_all_templates, expected at least 2 templates returned.'
     exit 1
   end
-  test_template_response(response.collection[0])
-  test_template_response(response.collection[1])
+  test_template_response(response.collection[0], 'test_get_all_templates')
+  test_template_response(response.collection[1], 'test_get_all_templates')
 end
 
 def test_get_all_templates_filter_by_type(client)
@@ -55,10 +56,16 @@ def test_get_all_templates_filter_by_type(client)
     p 'failed test_get_all_templates, expected at least 2 templates returned.'
     exit 1
   end
-  test_template_response(response.collection[0])
+  test_template_response(response.collection[0], 'test_get_all_templates')
 end
 
-def test_template_response(response)
+def test_generate_template_preview(client, id)
+
+  response = client.generate_template_preview(id, personalisation:Hash["name", "some name"])
+  test_template_preview(response)
+end
+
+def test_template_response(response, test_method)
   unless response.is_a?(Notifications::Client::Template) then
     p 'failed test_get_template_by_id response is not a Notifications::Client::Template'
     exit 1
@@ -67,7 +74,19 @@ def test_template_response(response)
     p 'failed template id is not a String'
     exit 1
   end
-  field_should_not_be_nil(expected_fields_in_template_response, response, 'get_template_by_id')
+  field_should_not_be_nil(expected_fields_in_template_response, response, test_method)
+end
+
+def test_template_preview(response)
+  unless response.is_a?(Notifications::Client::TemplatePreview) then
+    p 'failed test_generate_template_preview response is not a Notifications::Client::TemplatePreview'
+    exit 1
+  end
+  unless response.id.is_a?(String) then
+    p 'failed template id is not a String'
+    exit 1
+  end
+  field_should_not_be_nil(expected_fields_in_template_preview, response, 'generate_template_preview')
 end
 
 def test_send_email_endpoint(client)
@@ -159,6 +178,13 @@ def expected_fields_in_template_response
      type
      created_at
      created_by
+     body
+     version
+)
+end
+
+def expected_fields_in_template_preview
+  %w(id
      body
      version
 )

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -4,10 +4,14 @@ require 'notifications/client/notification'
 require 'notifications/client/response_notification'
 require 'notifications/client/notification'
 require 'notifications/client/response_template'
+require 'notifications/client/template_collection'
 
 def main
   client = Notifications::Client.new(ENV['API_KEY'], ENV['NOTIFY_API_URL'])
   test_get_template_by_id(client, ENV['EMAIL_TEMPLATE_ID'])
+  test_get_template_version(client, ENV['SMS_TEMPLATE_ID'], 1)
+  test_get_all_templates(client)
+  test_get_all_templates_filter_by_type(client)
   # email_notification = test_send_email_endpoint(client)
   # sms_notification = test_send_sms_endpoint(client)
   # test_get_notification_by_id_endpoint(client, email_notification.id, 'email')
@@ -19,9 +23,39 @@ end
 
 def test_get_template_by_id(client, id)
   response = client.get_template_by_id(id)
-  p response
-
   test_template_response(response)
+end
+
+def test_get_template_version(client, id, version)
+  response = client.get_template_version(id, version)
+  test_template_response(response)
+end
+
+def test_get_all_templates(client)
+  response = client.get_all_templates()
+  unless response.is_a?(Notifications::Client::TemplateCollection) then
+    p 'failed test_get_all_templates response is not a Notifications::Client::TemplateCollection'
+    exit 1
+  end
+  unless response.collection.length >= 2 then
+    p 'failed test_get_all_templates, expected at least 2 templates returned.'
+    exit 1
+  end
+  test_template_response(response.collection[0])
+  test_template_response(response.collection[1])
+end
+
+def test_get_all_templates_filter_by_type(client)
+  response = client.get_all_templates({'type' => 'sms'})
+  unless response.is_a?(Notifications::Client::TemplateCollection) then
+    p 'failed test_get_all_templates response is not a Notifications::Client::TemplateCollection'
+    exit 1
+  end
+  unless response.collection.length >= 1 then
+    p 'failed test_get_all_templates, expected at least 2 templates returned.'
+    exit 1
+  end
+  test_template_response(response.collection[0])
 end
 
 def test_template_response(response)

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -187,6 +187,7 @@ def expected_fields_in_template_preview
   %w(id
      body
      version
+     type
 )
 end
 

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -3,6 +3,7 @@ require "notifications/client/speaker"
 require "notifications/client/notification"
 require "notifications/client/response_notification"
 require "notifications/client/notifications_collection"
+require "notifications/client/response_template"
 require "forwardable"
 
 module Notifications
@@ -64,6 +65,15 @@ module Notifications
     def get_notifications(options = {})
       NotificationsCollection.new(
         speaker.get(nil, options)
+      )
+    end
+
+    ##
+    # @param id [String]
+    # @return [Template]
+    def get_template_by_id(id, options = {})
+      Template.new(
+        speaker.get_template(id, options)
       )
     end
   end

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -84,7 +84,7 @@ module Notifications
     # @param version [int]
     # @return [Template]
     def get_template_version(id, version, options = {})
-      path = "/v2/template/" << id << "/version/" << version
+      path = "/v2/template/" << id << "/version/" << version.to_s
       Template.new(
         speaker.get_with_url(path, options)
       )

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -5,6 +5,7 @@ require "notifications/client/response_notification"
 require "notifications/client/notifications_collection"
 require "notifications/client/response_template"
 require "notifications/client/template_collection"
+require "notifications/client/template_preview"
 require "forwardable"
 
 module Notifications
@@ -98,6 +99,17 @@ module Notifications
       path = "/v2/templates"
       TemplateCollection.new(
         speaker.get_with_url(path, options)
+      )
+    end
+
+    ##
+    # @param options [String]
+    # @option personalisation [Hash]
+    # @return [TemplatePreview]
+    def generate_template_preview(id, options = {})
+      path = "/v2/template/" << id << "/preview"
+      TemplatePreview.new(
+        speaker.post_with_url(path, options)
       )
     end
 

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -4,6 +4,7 @@ require "notifications/client/notification"
 require "notifications/client/response_notification"
 require "notifications/client/notifications_collection"
 require "notifications/client/response_template"
+require "notifications/client/template_collection"
 require "forwardable"
 
 module Notifications
@@ -85,6 +86,17 @@ module Notifications
     def get_template_version(id, version, options = {})
       path = "/v2/template/" << id << "/version/" << version
       Template.new(
+        speaker.get_with_url(path, options)
+      )
+    end
+
+    ##
+    # @option options [String] :type
+    #   email, sms, letter
+    # @return [TemplateCollection]
+    def get_all_templates(options = {})
+      path = "/v2/templates"
+      TemplateCollection.new(
         speaker.get_with_url(path, options)
       )
     end

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -72,9 +72,22 @@ module Notifications
     # @param id [String]
     # @return [Template]
     def get_template_by_id(id, options = {})
+      path = "/v2/template/" << id
       Template.new(
-        speaker.get_template(id, options)
+        speaker.get_with_url(path, options)
       )
     end
+
+    ##
+    # @param id [String]
+    # @param version [int]
+    # @return [Template]
+    def get_template_version(id, version, options = {})
+      path = "/v2/template/" << id << "/version/" << version
+      Template.new(
+        speaker.get_with_url(path, options)
+      )
+    end
+
   end
 end

--- a/lib/notifications/client/response_template.rb
+++ b/lib/notifications/client/response_template.rb
@@ -1,0 +1,41 @@
+module Notifications
+  class Client
+    class Template
+      FIELDS = [
+        :id,
+        :type,
+        :created_at,
+        :updated_at,
+        :created_by,
+        :version,
+        :body,
+        :subject
+      ].freeze
+
+            attr_reader(*FIELDS)
+
+            def initialize(notification)
+
+              FIELDS.each do |field|
+                  instance_variable_set(:"@#{field}", notification.fetch(field.to_s, nil)
+                  )
+              end
+            end
+
+            [
+              :created_at,
+              :updated_at
+            ].each do |field|
+              define_method field do
+                begin
+                  value = instance_variable_get(:"@#{field}")
+                  Time.parse value
+                rescue
+                  value
+                end
+              end
+            end
+
+          end
+        end
+      end

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -11,7 +11,6 @@ module Notifications
       attr_reader :secret_token
 
       BASE_PATH = "/v2/notifications".freeze
-      TEMPLATE_BASE_PATH = "/v2/template".freeze
       USER_AGENT = "NOTIFY-API-RUBY-CLIENT/#{Notifications::Client::VERSION}".freeze
 
       ##
@@ -65,9 +64,8 @@ module Notifications
       # @param id [String]
       # @param options [Hash] query
       # @see #perform_request!
-      def get_template(id = nil, options = {})
-        path = TEMPLATE_BASE_PATH.dup
-        path << "/" << id if id
+      def get_with_url(url, options = {})
+        path = url
         path << "?" << URI.encode_www_form(options) if options.any?
         request = Net::HTTP::Get.new(path, headers)
         perform_request!(request)

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -61,6 +61,7 @@ module Notifications
       end
 
       ##
+      # @param url path of endpoint
       # @param id [String]
       # @param options [Hash] query
       # @see #perform_request!
@@ -68,6 +69,23 @@ module Notifications
         path = url
         path << "?" << URI.encode_www_form(options) if options.any?
         request = Net::HTTP::Get.new(path, headers)
+        perform_request!(request)
+      end
+
+      ##
+      # @param url [String] path of the endpoint
+      # @param form_data [Hash]
+      # @option form_data [String] :template_id
+      #   id of the template to render
+      # @option form_data [Hash] :personalisation
+      #   fields to use in the template
+      # @see #perform_request!
+      def post_with_url(url, form_data)
+        request = Net::HTTP::Post.new(
+          url,
+          headers
+        )
+        request.body = form_data.is_a?(Hash) ? form_data.to_json : form_data
         perform_request!(request)
       end
 

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -11,6 +11,7 @@ module Notifications
       attr_reader :secret_token
 
       BASE_PATH = "/v2/notifications".freeze
+      TEMPLATE_BASE_PATH = "/v2/template".freeze
       USER_AGENT = "NOTIFY-API-RUBY-CLIENT/#{Notifications::Client::VERSION}".freeze
 
       ##
@@ -54,6 +55,18 @@ module Notifications
       # @see #perform_request!
       def get(id = nil, options = {})
         path = BASE_PATH.dup
+        path << "/" << id if id
+        path << "?" << URI.encode_www_form(options) if options.any?
+        request = Net::HTTP::Get.new(path, headers)
+        perform_request!(request)
+      end
+
+      ##
+      # @param id [String]
+      # @param options [Hash] query
+      # @see #perform_request!
+      def get_template(id = nil, options = {})
+        path = TEMPLATE_BASE_PATH.dup
         path << "/" << id if id
         path << "?" << URI.encode_www_form(options) if options.any?
         request = Net::HTTP::Get.new(path, headers)

--- a/lib/notifications/client/template_collection.rb
+++ b/lib/notifications/client/template_collection.rb
@@ -1,0 +1,16 @@
+module Notifications
+  class Client
+    class TemplateCollection
+      attr_reader :collection
+      def initialize(response)
+        @collection = collection_from(response["templates"])
+      end
+
+      def collection_from(templates)
+        templates.map do |template|
+          Template.new(template)
+        end
+      end
+    end
+    end
+    end

--- a/lib/notifications/client/template_preview.rb
+++ b/lib/notifications/client/template_preview.rb
@@ -5,7 +5,8 @@ module Notifications
         :id,
         :version,
         :body,
-        :subject
+        :subject,
+        :type
       ].freeze
 
             attr_reader(*FIELDS)

--- a/lib/notifications/client/template_preview.rb
+++ b/lib/notifications/client/template_preview.rb
@@ -1,0 +1,22 @@
+module Notifications
+  class Client
+    class TemplatePreview
+      FIELDS = [
+        :id,
+        :version,
+        :body,
+        :subject
+      ].freeze
+
+            attr_reader(*FIELDS)
+
+            def initialize(notification)
+
+              FIELDS.each do |field|
+                  instance_variable_set(:"@#{field}", notification.fetch(field.to_s, nil)
+                  )
+              end
+            end
+    end
+  end
+end

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -1,5 +1,5 @@
 module Notifications
   class Client
-    VERSION = "2.0.0".freeze
+    VERSION = "2.1.0".freeze
   end
 end

--- a/spec/factories/template_list.rb
+++ b/spec/factories/template_list.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :client_template_collection,
+          class: Notifications::Client::TemplateCollection do
+    initialize_with do
+      new(body)
+    end
+
+    body do
+      {
+        "templates" => 2.times.map {
+          attributes_for(:client_template_response)[:body]
+        }
+      }
+    end
+  end
+end

--- a/spec/factories/template_preview.rb
+++ b/spec/factories/template_preview.rb
@@ -10,7 +10,8 @@ FactoryGirl.define do
         "id" => "f163deaf-2d3f-4ec6-98fc-f23fa511518f",
         "body" => "Contents of template Mr Big Nose",
         "subject" => "Subject of the email",
-        "version" => "2"
+        "version" => "2",
+        "type" => "email"
       }
     end
   end

--- a/spec/factories/template_preview.rb
+++ b/spec/factories/template_preview.rb
@@ -1,0 +1,17 @@
+FactoryGirl.define do
+  factory :client_template_preview,
+          class: Notifications::Client::TemplatePreview do
+    initialize_with do
+      new(body)
+    end
+
+    body do
+      {
+        "id" => "f163deaf-2d3f-4ec6-98fc-f23fa511518f",
+        "body" => "Contents of template Mr Big Nose",
+        "subject" => "Subject of the email",
+        "version" => "2"
+      }
+    end
+  end
+end

--- a/spec/factories/template_response.rb
+++ b/spec/factories/template_response.rb
@@ -1,0 +1,21 @@
+FactoryGirl.define do
+  factory :client_template_response,
+          class: Notifications::Client::Template do
+    initialize_with do
+      new(body)
+    end
+
+    body do
+      {
+        "id" => "f163deaf-2d3f-4ec6-98fc-f23fa511518f",
+        "type" => "email",
+        "created_at" => "2016-11-29T11:12:30.12354Z",
+        "updated_at" => "2016-11-29T11:12:40.12354Z",
+        "created_by" => "jane.doe@gmail.com",
+        "body" => "Contents of template ((place_holder))",
+        "subject" => "Subject of the email",
+        "version" => "2"
+      }
+    end
+  end
+end

--- a/spec/notifications/client/generate_template_preview_spec.rb
+++ b/spec/notifications/client/generate_template_preview_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+describe Notifications::Client do
+  let(:client) { build :notifications_client }
+
+  let(:uri) {
+    URI.parse(Notifications::Client::PRODUCTION_BASE_URL)
+  }
+
+  describe "generate template preview" do
+    let(:id) {
+      "1"
+    }
+    let(:personalisation){
+      {"name": "Mr Big Nose"}
+    }
+
+    let(:template_preview) {
+      client.generate_template_preview(id, personalisation)
+    }
+
+    let(:mocked_response) {
+      attributes_for(:client_template_preview)[:body]
+    }
+
+    before do
+      stub_request(
+        :post,
+        "https://#{uri.host}:#{uri.port}/v2/template/#{id}/preview"
+      ).to_return(body: mocked_response.to_json)
+    end
+
+    it "expects template preview" do
+      p template_preview
+      expect(template_preview).to be_a(
+        Notifications::Client::TemplatePreview
+      )
+    end
+
+    %w(
+      id
+      body
+      subject
+      version
+    ).each do |field|
+      it "expect to include #{field}" do
+        expect(
+          template_preview.send(field)
+        ).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/notifications/client/get_all_templates_spec.rb
+++ b/spec/notifications/client/get_all_templates_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+describe Notifications::Client do
+  let(:client) { build :notifications_client }
+
+  let(:uri) {
+    URI.parse(Notifications::Client::PRODUCTION_BASE_URL)
+  }
+
+  describe "get all templates" do
+    let(:templates) {
+      client.get_all_templates()
+    }
+
+    let(:mocked_response) {
+      attributes_for(:client_template_collection)[:body]
+    }
+
+    before do
+      stub_request(
+        :get,
+        "https://#{uri.host}:#{uri.port}/v2/templates"
+      ).to_return(body: mocked_response.to_json)
+    end
+
+    it "expects TemplateCollection" do
+      expect(templates).to be_a(
+        Notifications::Client::TemplateCollection
+      )
+    end
+
+    it "collection contains all templates" do
+      expect(
+        templates.collection.count
+      ).to eq(mocked_response["templates"].count)
+    end
+
+    it "collection has templates" do
+      expect(
+        templates.collection.sample
+      ).to be_a(Notifications::Client::Template)
+    end
+  end
+end

--- a/spec/notifications/client/get_template_spec.rb
+++ b/spec/notifications/client/get_template_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+describe Notifications::Client do
+  let(:client) { build :notifications_client }
+
+  let(:uri) {
+    URI.parse(Notifications::Client::PRODUCTION_BASE_URL)
+  }
+
+  describe "get a template by id" do
+    let(:id) {
+      "1"
+    }
+
+    let(:template) {
+      client.get_template_by_id(id)
+    }
+
+    let(:mocked_response) {
+      attributes_for(:client_template_response)[:body]
+    }
+
+    before do
+      stub_request(
+        :get,
+        "https://#{uri.host}:#{uri.port}/v2/template/#{id}"
+      ).to_return(body: mocked_response.to_json)
+    end
+
+    it "expects template" do
+      expect(template).to be_a(
+        Notifications::Client::Template
+      )
+    end
+
+    %w(
+      id
+      type
+      body
+      created_at
+      updated_at
+      created_by
+      subject
+      version
+    ).each do |field|
+      it "expect to include #{field}" do
+        expect(
+          template.send(field)
+        ).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/notifications/client/get_template_version_spec.rb
+++ b/spec/notifications/client/get_template_version_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+describe Notifications::Client do
+  let(:client) { build :notifications_client }
+
+  let(:uri) {
+    URI.parse(Notifications::Client::PRODUCTION_BASE_URL)
+  }
+
+  describe "get a template by id and version" do
+    let(:id) {
+      "1"
+    }
+    let(:version) {
+      "1"
+    }
+    let(:template) {
+      client.get_template_version(id, version)
+    }
+
+    let(:mocked_response) {
+      attributes_for(:client_template_response)[:body]
+    }
+
+    before do
+      stub_request(
+        :get,
+        "https://#{uri.host}:#{uri.port}/v2/template/#{id}/version/#{version}"
+      ).to_return(body: mocked_response.to_json)
+    end
+
+    it "expects template" do
+      expect(template).to be_a(
+        Notifications::Client::Template
+      )
+    end
+
+    %w(
+      id
+      type
+      body
+      created_at
+      updated_at
+      created_by
+      subject
+      version
+    ).each do |field|
+      it "expect to include #{field}" do
+        expect(
+          template.send(field)
+        ).to_not be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Added methods to get templates and generate a preview of a template.
* `get_template_by_id` - get the latest version of a template by id.
* `get_template_version` - get the template by id and version.
* `get_all_templates` - get all templates, can be filtered by template type.
* `generate_template_preview` - get the contents of a template with the placeholders replaced with the given personalisation.