### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ You can omit this argument to ignore this filter.
 ## Generate a preview template
 This will return the contents of a template with the placeholders replaced with the given personalisation.
 ```ruby
-templatePreview = client.generate_template_preview(template_id: template_id,
+templatePreview = client.generate_template_preview(template_id,
                                                   personalisation: {
                                                       name: "name",
                                                       year: "2016",                      


### PR DESCRIPTION
Clarify the invocation of generate_template_preview. 

It is not expecting a hash for the `id` value, so it was returning a `TypeError: no implicit conversion of Hash into String` error.

Removing the key name allows the method to return the preview as expected.