### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->
+
+## What problem does the pull request solve?
+<!--- Describe why you’re making this change -->
+
+## Checklist
+
+<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
+- [x] I’ve used the pull request template
+- [ ] I’ve written unit tests for these changes
+- [ ] I’ve update the documentation (in `README.md`)
+- [ ] I’ve bumped the version number (in `lib/notifications/client/version.rb`)

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -1,3 +1,12 @@
+# Version numbering follows Semantic Versionning:
+#
+# Given a version number MAJOR.MINOR.PATCH, increment the:
+# - MAJOR version when you make incompatible API changes,
+# - MINOR version when you add functionality in a backwards-compatible manner, and
+# - PATCH version when you make backwards-compatible bug fixes.
+#
+# -- http://semver.org/
+
 module Notifications
   class Client
     VERSION = "2.3.0".freeze


### PR DESCRIPTION
We should clarify what our expectations are of external developers contributing to our codebase.

A good way to do this is through a pull request template, which lets developers check off what they’ve done. A lot of the GOV.UK frontend repos do this, eg
https://github.com/alphagov/govuk_elements/blob/3c5c43a6fd4209cf2b6d180e7a5eadf6fa94c132/.github/PULL_REQUEST_TEMPLATE.md

This commit also documents how we do version numbering, so that an external developer would have a reasonable chance of being able to increment the version number in the right way.