### PR TITLE
Loosen dependency on JWT

### DIFF
--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "2.5.0".freeze
+    VERSION = "2.5.1".freeze
   end
 end

--- a/notifications-ruby-client.gemspec
+++ b/notifications-ruby-client.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "jwt", "~> 2.1"
+  spec.add_runtime_dependency "jwt", ">= 1.5", "< 3"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
Hello :wave: from across the office. I'm on the GOV.UK Email team.

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

We've hit a problem installing versions of this gem beyond 2.2.0 as we hit dependency conflicts. The version of JWT that is required for this gem seems to be quite new (released in October) and this gem doesn't make use of any of the newer features. 

This change in dependency rules will still mean that in situations where you don't have another dependency that uses JWT you'll still have the latest version, however it won't forbid building for an application that has dependencies on earlier version of JWT.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `README.md`)
- [x] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
