### PR TITLE
Validate UUIDs derived from the API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.6.0
+
+### Changed
+* The client now validates that UUIDs derived from the API key are valid and raises a helpful error message if they are not.
+
 ## 2.5.0
 
 ### Changed

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -8,6 +8,7 @@ require_relative "client/received_text_collection"
 require_relative "client/response_template"
 require_relative "client/template_collection"
 require_relative "client/template_preview"
+require_relative "client/uuid_validator"
 require "forwardable"
 
 module Notifications

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -22,8 +22,7 @@ module Notifications
         @secret_token = secret_token[secret_token.length - 36..secret_token.length]
         @base_url = base_url || PRODUCTION_BASE_URL
 
-        UuidValidator.validate!(@service_id)
-        UuidValidator.validate!(@secret_token)
+        validate_uuids!
       end
 
       ##
@@ -132,6 +131,17 @@ module Notifications
           iat: Time.now.to_i
         }
         JWT.encode payload, @secret_token, "HS256"
+      end
+
+      def validate_uuids!
+        contextual_message = [
+          "This error is probably caused by initializing the Notifications client with an invalid API key.",
+          "You can generate a new API key by logging into Notify and visiting the 'API integration' page:",
+          "https://www.notifications.service.gov.uk",
+        ].join("\n")
+
+        UuidValidator.validate!(@service_id, contextual_message)
+        UuidValidator.validate!(@secret_token, contextual_message)
       end
     end
   end

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -21,6 +21,9 @@ module Notifications
         @service_id = secret_token[secret_token.length - 73..secret_token.length - 38]
         @secret_token = secret_token[secret_token.length - 36..secret_token.length]
         @base_url = base_url || PRODUCTION_BASE_URL
+
+        UuidValidator.validate!(@service_id)
+        UuidValidator.validate!(@secret_token)
       end
 
       ##

--- a/lib/notifications/client/uuid_validator.rb
+++ b/lib/notifications/client/uuid_validator.rb
@@ -13,9 +13,13 @@ module Notifications
       !!(uuid && uuid.match(REGEX))
     end
 
-    def self.validate!(uuid)
+    def self.validate!(uuid, contextual_message = nil)
       return if new(uuid).valid?
-      raise ArgumentError, "#{uuid.inspect} is not a valid uuid"
+
+      message = "#{uuid.inspect} is not a valid uuid"
+      message += "\n#{contextual_message}" if contextual_message
+
+      raise ArgumentError, message
     end
   end
 end

--- a/lib/notifications/client/uuid_validator.rb
+++ b/lib/notifications/client/uuid_validator.rb
@@ -1,0 +1,22 @@
+module Notifications
+  class UuidValidator
+    HEX = /[0-9a-f]/
+    REGEX = /^#{HEX}{8}-#{HEX}{4}-#{HEX}{4}-#{HEX}{4}-#{HEX}{12}$/
+
+    attr_accessor :uuid
+
+    def initialize(uuid)
+      self.uuid = uuid
+    end
+
+    def valid?
+      !!(uuid && uuid.match(REGEX))
+    end
+
+    def self.validate!(uuid)
+      return if new(uuid).valid?
+      raise ArgumentError, "#{uuid.inspect} is not a valid uuid"
+    end
+  end
+end
+

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "2.5.1".freeze
+    VERSION = "2.6.0".freeze
   end
 end

--- a/spec/factories/notifications_client.rb
+++ b/spec/factories/notifications_client.rb
@@ -11,20 +11,30 @@ FactoryBot.define do
 
   factory :notifications_client_combined,
           class: Notifications::Client do
-    jwt_service "test_key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
+    jwt_secret "test_key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
 
     initialize_with do
-      new(jwt_service)
+      new(jwt_secret)
     end
   end
 
   factory :notifications_client_combined_with_base_url,
           class: Notifications::Client do
     base_url { "http://example.com" }
-    jwt_service "test_key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
+    jwt_secret "test_key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
 
     initialize_with do
-      new(jwt_service, base_url)
+      new(jwt_secret, base_url)
+    end
+  end
+
+  factory :notifications_client_with_invalid_api_key,
+          class: Notifications::Client do
+    base_url { nil }
+    jwt_secret "test_key-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+    initialize_with do
+      new(jwt_secret, base_url)
     end
   end
 

--- a/spec/notifications/client/uuid_validator_spec.rb
+++ b/spec/notifications/client/uuid_validator_spec.rb
@@ -1,0 +1,49 @@
+describe Notifications::UuidValidator do
+  def assert_valid(uuid)
+    expect(described_class.new(uuid)).to be_valid,
+      "uuid: #{uuid} should be valid"
+  end
+
+  def assert_invalid(uuid)
+    expect(described_class.new(uuid)).not_to be_valid,
+      "uuid: #{uuid} should be invalid"
+  end
+
+  it "accepts valid uuids" do
+    assert_valid("00000000-0000-0000-0000-000000000000")
+    assert_valid("01234567-89ab-cdef-edcb-a98765432100")
+
+    100.times { assert_valid(SecureRandom.uuid) }
+  end
+
+  it "rejects invalid uuids" do
+    assert_invalid("not-a-valid-uuid")
+    assert_invalid("abcdefg-0000-0000-0000-0000000000000")
+    assert_invalid("000000000000000000000000000000000000")
+    assert_invalid("00000000-0000-0000-0000-0000000000")
+    assert_invalid("00000000------0000-0000-000000000000")
+    assert_invalid(nil)
+  end
+
+  describe ".validate!" do
+    context "for a valid uuid" do
+      let(:uuid) { "00000000-0000-0000-0000-000000000000" }
+
+      it "does not raise" do
+        expect { described_class.validate!(uuid) }.not_to raise_error
+      end
+    end
+
+    context "for an invalid uuid" do
+      let(:uuid) { "not-a-valid-uuid" }
+
+      it "raises a helpful error" do
+        expect { described_class.validate!(uuid) }
+          .to raise_error(ArgumentError, '"not-a-valid-uuid" is not a valid uuid')
+
+        expect { described_class.validate!(nil) }
+          .to raise_error(ArgumentError, 'nil is not a valid uuid')
+      end
+    end
+  end
+end

--- a/spec/notifications/client/uuid_validator_spec.rb
+++ b/spec/notifications/client/uuid_validator_spec.rb
@@ -44,6 +44,13 @@ describe Notifications::UuidValidator do
         expect { described_class.validate!(nil) }
           .to raise_error(ArgumentError, 'nil is not a valid uuid')
       end
+
+      context "when a contextual message is provided" do
+        it "includes it in the error message" do
+          expect { described_class.validate!(uuid, "please check that ...") }
+            .to raise_error(ArgumentError, /please check that .../)
+        end
+      end
     end
   end
 end

--- a/spec/notifications/client_spec.rb
+++ b/spec/notifications/client_spec.rb
@@ -54,6 +54,10 @@ describe Notifications::Client do
     it "raises a helpful error" do
       expect { client }.to raise_error(ArgumentError, /is not a valid uuid/)
     end
+
+    it "includes contextual information in the error" do
+      expect { client }.to raise_error(ArgumentError, /this error is probably caused by/i)
+    end
   end
 
   describe "#base_url" do

--- a/spec/notifications/client_spec.rb
+++ b/spec/notifications/client_spec.rb
@@ -48,6 +48,14 @@ describe Notifications::Client do
     end
   end
 
+  describe "with an invalid API key" do
+    let(:client) { build :notifications_client_with_invalid_api_key }
+
+    it "raises a helpful error" do
+      expect { client }.to raise_error(ArgumentError, /is not a valid uuid/)
+    end
+  end
+
   describe "#base_url" do
     describe "default base url" do
       let(:client) { build :notifications_client }


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

We were receiving some difficult to understand errors inside the `jwt` gem caused by setting the API key to something invalid. This change makes it check the UUIDs derived from the API key are valid on initialisation of the client and provides a helpful error message if they are invalid.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- ~[ ] I’ve update the documentation (in `README.md`)~ (probably not applicable?)
- [x] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
