### PR TITLE
Test that methods hit the correct endpoint of notifications-api

### DIFF
--- a/spec/notifications/client/email_notification_spec.rb
+++ b/spec/notifications/client/email_notification_spec.rb
@@ -42,5 +42,10 @@ describe Notifications::Client do
         ).to_not be_nil
       end
     end
+
+    it "hits the correct API endpoint" do
+      expect(WebMock).to have_requested(:post, "https://#{uri.host}:#{uri.port}/v2/notifications/email").
+        with(body: { email_address: "email@gov.uk", template_id: "f6895ff7-86e0-4d38-80ab-c9525856c3ff" })
+    end
   end
 end

--- a/spec/notifications/client/generate_template_preview_spec.rb
+++ b/spec/notifications/client/generate_template_preview_spec.rb
@@ -6,6 +6,13 @@ describe Notifications::Client do
   }
 
   describe "generate template preview" do
+    before do
+      stub_request(
+        :post,
+        "https://#{uri.host}:#{uri.port}/v2/template/#{id}/preview"
+      ).to_return(body: mocked_response.to_json)
+    end
+
     let(:id) {
       "1"
     }
@@ -13,20 +20,13 @@ describe Notifications::Client do
       { name: "Mr Big Nose" }
     }
 
-    let(:template_preview) {
+    let!(:template_preview) {
       client.generate_template_preview(id, personalisation)
     }
 
     let(:mocked_response) {
       attributes_for(:client_template_preview)[:body]
     }
-
-    before do
-      stub_request(
-        :post,
-        "https://#{uri.host}:#{uri.port}/v2/template/#{id}/preview"
-      ).to_return(body: mocked_response.to_json)
-    end
 
     it "expects template preview" do
       expect(template_preview).to be_a(
@@ -45,6 +45,11 @@ describe Notifications::Client do
           template_preview.send(field)
         ).to_not be_nil
       end
+    end
+
+    it "hits the correct API endpoint" do
+      expect(WebMock).to have_requested(:post, "https://#{uri.host}:#{uri.port}/v2/template/#{id}/preview").
+        with(body: { name: "Mr Big Nose" })
     end
   end
 end

--- a/spec/notifications/client/get_all_templates_spec.rb
+++ b/spec/notifications/client/get_all_templates_spec.rb
@@ -5,19 +5,19 @@ describe Notifications::Client do
     URI.parse(Notifications::Client::PRODUCTION_BASE_URL)
   }
 
+  let(:mocked_response) {
+    attributes_for(:client_template_collection)[:body]
+  }
+
   describe "get all templates" do
-    let(:templates) { client.get_all_templates }
-
-    let(:mocked_response) {
-      attributes_for(:client_template_collection)[:body]
-    }
-
     before do
       stub_request(
         :get,
         "https://#{uri.host}:#{uri.port}/v2/templates"
       ).to_return(body: mocked_response.to_json)
     end
+
+    let!(:templates) { client.get_all_templates }
 
     it "expects TemplateCollection" do
       expect(templates).to be_a(
@@ -35,6 +35,27 @@ describe Notifications::Client do
       expect(
         templates.collection.sample
       ).to be_a(Notifications::Client::Template)
+    end
+
+    it "hits the correct API endpoint with no parameters" do
+      expect(WebMock).to have_requested(:get, "https://#{uri.host}:#{uri.port}/v2/templates")
+    end
+  end
+
+  describe "get templates by query" do
+    before do
+      stub_request(
+        :get,
+        "https://#{uri.host}:#{uri.port}/v2/templates?template_type=sms"
+      ).to_return(body: mocked_response.to_json)
+    end
+
+    it "hits the correct API endpoint when filtering by template type" do
+      args = { template_type: "sms" }
+
+      client.get_all_templates(args)
+
+      expect(WebMock).to have_requested(:get, "https://#{uri.host}:#{uri.port}/v2/templates").with(query: args)
     end
   end
 end

--- a/spec/notifications/client/get_notification_spec.rb
+++ b/spec/notifications/client/get_notification_spec.rb
@@ -6,24 +6,24 @@ describe Notifications::Client do
   }
 
   describe "get a notification by id" do
-    let(:id) {
-      "1"
-    }
-
-    let(:notification) {
-      client.get_notification(id)
-    }
-
-    let(:mocked_response) {
-      attributes_for(:client_notification)[:body]
-    }
-
     before do
       stub_request(
         :get,
         "https://#{uri.host}:#{uri.port}/v2/notifications/#{id}"
       ).to_return(body: mocked_response.to_json)
     end
+
+    let(:id) {
+      "1"
+    }
+
+    let!(:notification) {
+      client.get_notification(id)
+    }
+
+    let(:mocked_response) {
+      attributes_for(:client_notification)[:body]
+    }
 
     it "expects notification" do
       expect(notification).to be_a(
@@ -52,6 +52,10 @@ describe Notifications::Client do
 
     it "parses the time correctly" do
       expect(notification.created_at.to_s).to eq("2016-11-29 11:12:30 UTC")
+    end
+
+    it "hits the correct API endpoint" do
+      expect(WebMock).to have_requested(:get, "https://#{uri.host}:#{uri.port}/v2/notifications/#{id}")
     end
   end
 end

--- a/spec/notifications/client/get_notifications_spec.rb
+++ b/spec/notifications/client/get_notifications_spec.rb
@@ -6,20 +6,20 @@ describe Notifications::Client do
   }
 
   describe "get all notifications" do
-    let(:notifications) {
-      client.get_notifications
-    }
-
-    let(:mocked_response) {
-      attributes_for(:client_notifications_collection)[:body]
-    }
-
     before do
       stub_request(
         :get,
         "https://#{uri.host}:#{uri.port}/v2/notifications"
       ).to_return(body: mocked_response.to_json)
     end
+
+    let!(:notifications) {
+      client.get_notifications
+    }
+
+    let(:mocked_response) {
+      attributes_for(:client_notifications_collection)[:body]
+    }
 
     it "collection contains all notifications" do
       expect(
@@ -32,9 +32,20 @@ describe Notifications::Client do
         notifications.collection.sample
       ).to be_a(Notifications::Client::Notification)
     end
+
+    it "requests all notifications with no parameters" do
+      expect(WebMock).to have_requested(:get, "https://#{uri.host}:#{uri.port}/v2/notifications")
+    end
   end
 
   describe "get notifications by query" do
+    before do
+      stub_request(
+        :get,
+        "https://#{uri.host}:#{uri.port}/v2/notifications?#{request_path}"
+      ).to_return(body: mocked_response.to_json)
+    end
+
     let(:options) {
       {
         "template_type" => "sms",
@@ -42,7 +53,7 @@ describe Notifications::Client do
       }
     }
 
-    let(:notifications) {
+    let!(:notifications) {
       client.get_notifications(
         options
       )
@@ -58,15 +69,7 @@ describe Notifications::Client do
       URI.encode_www_form(options)
     }
 
-    before do
-      stub_request(
-        :get,
-        "https://#{uri.host}:#{uri.port}/v2/notifications?#{request_path}"
-      ).to_return(body: mocked_response.to_json)
-    end
-
     it "expect to request with right parameters" do
-      notifications
       expect(WebMock).to have_requested(
         :get,
         "https://#{uri.host}:#{uri.port}/v2/notifications"

--- a/spec/notifications/client/get_template_spec.rb
+++ b/spec/notifications/client/get_template_spec.rb
@@ -6,24 +6,24 @@ describe Notifications::Client do
   }
 
   describe "get a template by id" do
-    let(:id) {
-      "1"
-    }
-
-    let(:template) {
-      client.get_template_by_id(id)
-    }
-
-    let(:mocked_response) {
-      attributes_for(:client_template_response)[:body]
-    }
-
     before do
       stub_request(
         :get,
         "https://#{uri.host}:#{uri.port}/v2/template/#{id}"
       ).to_return(body: mocked_response.to_json)
     end
+
+    let(:id) {
+      "1"
+    }
+
+    let!(:template) {
+      client.get_template_by_id(id)
+    }
+
+    let(:mocked_response) {
+      attributes_for(:client_template_response)[:body]
+    }
 
     it "expects template" do
       expect(template).to be_a(
@@ -50,6 +50,10 @@ describe Notifications::Client do
 
     it "parses the time correctly" do
       expect(template.created_at.to_s).to eq("2016-11-29 11:12:30 UTC")
+    end
+
+    it "hits the correct API endpoint" do
+      expect(WebMock).to have_requested(:get, "https://#{uri.host}:#{uri.port}/v2/template/#{id}")
     end
   end
 end

--- a/spec/notifications/client/get_template_version_spec.rb
+++ b/spec/notifications/client/get_template_version_spec.rb
@@ -6,26 +6,26 @@ describe Notifications::Client do
   }
 
   describe "get a template by id and version" do
-    let(:id) {
-      "1"
-    }
-    let(:version) {
-      "1"
-    }
-    let(:template) {
-      client.get_template_version(id, version)
-    }
-
-    let(:mocked_response) {
-      attributes_for(:client_template_response)[:body]
-    }
-
     before do
       stub_request(
         :get,
         "https://#{uri.host}:#{uri.port}/v2/template/#{id}/version/#{version}"
       ).to_return(body: mocked_response.to_json)
     end
+
+    let(:id) {
+      "1"
+    }
+    let(:version) {
+      "1"
+    }
+    let!(:template) {
+      client.get_template_version(id, version)
+    }
+
+    let(:mocked_response) {
+      attributes_for(:client_template_response)[:body]
+    }
 
     it "expects template" do
       expect(template).to be_a(
@@ -48,6 +48,10 @@ describe Notifications::Client do
           template.send(field)
         ).to_not be_nil
       end
+    end
+
+    it "hits the correct API endpoint" do
+      expect(WebMock).to have_requested(:get, "https://#{uri.host}:#{uri.port}/v2/template/#{id}/version/#{version}")
     end
   end
 end

--- a/spec/notifications/client/letter_notification_spec.rb
+++ b/spec/notifications/client/letter_notification_spec.rb
@@ -46,5 +46,17 @@ describe Notifications::Client do
         ).to_not be_nil
       end
     end
+
+    it "hits the correct API endpoint" do
+      expect(WebMock).to have_requested(:post, "https://#{uri.host}:#{uri.port}/v2/notifications/letter").
+        with(body: {
+          template_id: "f6895ff7-86e0-4d38-80ab-c9525856c3ff",
+          personalisation: {
+            address_line_1: "The Occupier",
+            address_line_2: "123 High Street",
+            postcode: "SW14 6BH"
+          }
+        })
+    end
   end
 end

--- a/spec/notifications/client/sms_notification_spec.rb
+++ b/spec/notifications/client/sms_notification_spec.rb
@@ -20,7 +20,7 @@ describe Notifications::Client do
     let!(:sent_sms) {
       client.send_sms(
         phone_number: "+44 7700 900 404",
-        template: "f6895ff7-86e0-4d38-80ab-c9525856c3ff"
+        template_id: "f6895ff7-86e0-4d38-80ab-c9525856c3ff"
       )
     }
 
@@ -41,6 +41,11 @@ describe Notifications::Client do
           sent_sms.send(field)
         ).to_not be_nil
       end
+    end
+
+    it "hits the correct API endpoint" do
+      expect(WebMock).to have_requested(:post, "https://#{uri.host}:#{uri.port}/v2/notifications/sms").
+        with(body: { phone_number: "+44 7700 900 404", template_id: "f6895ff7-86e0-4d38-80ab-c9525856c3ff" })
     end
   end
 end


### PR DESCRIPTION
Updated the unit tests to test that the methods are hitting the correct endpoints in notifications-api. This makes the tests for the ruby client more consistent with tests for the other clients.

[Pivotal story](https://www.pivotaltracker.com/story/show/153281515)