### PR TITLE
Add created_by_name to Notification response and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.7.0
+
+* The Notification class has a new `created_by_name` property.
+    * If the notification was sent manually this will be the name of the sender. If the notification was sent through the API this will be `nil`.
+
 ## 2.6.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ notification.subject                # => the subject of the notification (email 
 notification.sent_at                # => date and time the notification was sent to the provider
 notification.created_at             # => date and time the notification was created
 notification.completed_at           # => date and time the notification was delivered or failed
+notification.created_by_name        # => name of the person who sent the notification if sent manually
 ```
 Otherwise a `Notification::Client::RequestError` is raised
 

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -252,7 +252,8 @@ def expected_fields_in_email_notification_that_are_nil
      line_5
      line_5
      line_6
-     postcode)
+     postcode
+     created_by_name)
 end
 
 def expected_fields_in_sms_notification
@@ -275,7 +276,8 @@ def expected_fields_in_sms_notification_that_are_nil
      line_5
      line_6
      postcode
-     subject)
+     subject
+     created_by_name)
 end
 
 def expected_fields_in_letter_notification
@@ -302,6 +304,7 @@ def expected_fields_in_letter_notification_that_are_nil
     line_5
     line_5
     line_6
+    created_by_name
   )
 end
 

--- a/lib/notifications/client/notification.rb
+++ b/lib/notifications/client/notification.rb
@@ -23,6 +23,7 @@ module Notifications
         sent_at
         created_at
         completed_at
+        created_by_name
       ).freeze
 
       attr_reader(*FIELDS)

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "2.6.0".freeze
+    VERSION = "2.7.0".freeze
   end
 end

--- a/notifications-ruby-client.gemspec
+++ b/notifications-ruby-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"
-  spec.add_development_dependency "webmock", "~> 3.1"
-  spec.add_development_dependency "factory_bot", "~> 4.8"
-  spec.add_development_dependency "govuk-lint", "~> 3.3"
+  spec.add_development_dependency "webmock", "~> 3.4"
+  spec.add_development_dependency "factory_bot", "~> 4.10"
+  spec.add_development_dependency "govuk-lint", "~> 3.8"
 end

--- a/spec/factories/client_notifications.rb
+++ b/spec/factories/client_notifications.rb
@@ -30,7 +30,8 @@ FactoryBot.define do
         "subject" => nil,
         "created_at" => "2016-11-29T11:12:30.12354Z",
         "sent_at" => "2016-11-29T11:12:40.12354Z",
-        "completed_at" => "2016-11-29T11:12:52.12354Z"
+        "completed_at" => "2016-11-29T11:12:52.12354Z",
+        "created_by_name" => "A. Sender",
       }
     end
   end

--- a/spec/notifications/client/get_notification_spec.rb
+++ b/spec/notifications/client/get_notification_spec.rb
@@ -42,6 +42,7 @@ describe Notifications::Client do
       created_at
       sent_at
       completed_at
+      created_by_name
     ).each do |field|
       it "expect to include #{field}" do
         expect(


### PR DESCRIPTION
The `Notification` class now has an additional property, `created_by_name`. This affects the return value of the `.get_notification` method.

Also updated the minor versions of some development dependencies and bumped the gem version from 2.6.0 to 2.7.0.