### PR TITLE
 Return 'name' when fetching a template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.8.0
+
+* Updated the Template class to have a `name` property, which is the name of the template as set in Notify.
+
+
 ## 2.7.0
 
 * The Notification class has a new `created_by_name` property.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -581,6 +581,7 @@ You can then call different methods on this object to return the requested infor
 |Method|Information|Type|
 |:---|:---|:---|
 |`response.id`|Template UUID|String|
+|`response.name`|Template name|String|
 |`response.type`|Template type (email/sms/letter)|String|
 |`response.created_at`|Date and time template created|String|
 |`response.updated_at`|Date and time template last updated (may be nil if version 1)|String|
@@ -633,6 +634,7 @@ You can then call different methods on this object to return the requested infor
 |Method|Information|Type|
 |:---|:---|:---|
 |`response.id`|Template UUID|String|
+|`response.name`|Template name|String|
 |`response.type`|Template type (email/sms/letter)|String|
 |`response.created_at`|Date and time template created|String|
 |`response.updated_at`|Date and time template last updated (may be nil if it is the first version)|String|
@@ -686,6 +688,7 @@ Once the client has returned a template array, you must then call the following 
 |Method|Information|Type|
 |:---|:---|:---|
 |`response.id`|Template UUID|String|
+|`response.name`|Template name|String|
 |`response.type`|Template type (email/sms/letter)|String|
 |`response.created_at`|Date and time template created|String|
 |`response.updated_at`|Date and time template last updated (may be nil if it is the first version)|String|

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -193,6 +193,7 @@ end
 
 def expected_fields_in_template_response
   %w(id
+     name
      type
      created_at
      created_by

--- a/lib/notifications/client/response_template.rb
+++ b/lib/notifications/client/response_template.rb
@@ -6,6 +6,7 @@ module Notifications
       FIELDS = %i(
         id
         type
+        name
         created_at
         updated_at
         created_by

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "2.7.0".freeze
+    VERSION = "2.8.0".freeze
   end
 end

--- a/spec/factories/template_response.rb
+++ b/spec/factories/template_response.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     body do
       {
         "id" => "f163deaf-2d3f-4ec6-98fc-f23fa511518f",
+        "name" => "My template name",
         "type" => "email",
         "created_at" => "2016-11-29T11:12:30.12354Z",
         "updated_at" => "2016-11-29T11:12:40.12354Z",

--- a/spec/notifications/client/get_template_spec.rb
+++ b/spec/notifications/client/get_template_spec.rb
@@ -33,6 +33,7 @@ describe Notifications::Client do
 
     %w(
       id
+      name
       type
       body
       created_at

--- a/spec/notifications/client/get_template_version_spec.rb
+++ b/spec/notifications/client/get_template_version_spec.rb
@@ -35,6 +35,7 @@ describe Notifications::Client do
 
     %w(
       id
+      name
       type
       body
       created_at


### PR DESCRIPTION
The `Template` class now has a `name` property, which is the name of the template as set in Notify.

This change affects the response from these two methods:
* `get_template_by_id`
* `get_template_version`

[Pivotal story](https://www.pivotaltracker.com/story/show/160020331)