### PR TITLE
Add document download helper method and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.9.0
 
 * Added the `send_precompiled_letter` method which allows the client to send letters as PDF files.
   * This requires two arguments - a reference for the letter and the PDF letter file. The file must conform to the Notify printing template.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Added the `send_precompiled_letter` method which allows the client to send letters as PDF files.
   * This requires two arguments - a reference for the letter and the PDF letter file. The file must conform to the Notify printing template.
-
+* Added support for document uploads using the `send_email` method.
 
 ## 2.8.0
 

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -9,10 +9,12 @@ def main
   test_get_all_templates_filter_by_type(client)
   test_generate_template_preview(client, ENV['EMAIL_TEMPLATE_ID'])
   email_notification = test_send_email_endpoint(client)
+  email_notification_with_document = test_send_email_endpoint_with_document(client)
   sms_notification = test_send_sms_endpoint(client)
   letter_notification = test_send_letter_endpoint(client)
   precompiled_letter_notification = test_send_precompiled_letter_endpoint(client)
   test_get_notification_by_id_endpoint(client, email_notification.id, 'email')
+  test_get_notification_by_id_endpoint(client, email_notification_with_document.id, 'email')
   test_get_notification_by_id_endpoint(client, sms_notification.id, 'sms')
   test_get_notification_by_id_endpoint(client, letter_notification.id, 'letter')
   test_get_notification_by_id_endpoint(client, precompiled_letter_notification.id, 'precompiled_letter')
@@ -95,6 +97,19 @@ def test_send_email_endpoint(client)
                                  personalisation: { "name" => "some name" },
                                  reference: "some reference",
                                  email_reply_to_id: ENV['EMAIL_REPLY_TO_ID'])
+  test_notification_response_data_type(email_resp, 'email')
+  email_resp
+end
+
+def test_send_email_endpoint_with_document(client)
+  email_resp = File.open('spec/test_files/test_pdf.pdf', 'rb') do |f|
+    client.send_email(email_address: ENV['FUNCTIONAL_TEST_EMAIL'],
+      template_id: ENV['EMAIL_TEMPLATE_ID'],
+      personalisation: { name: Notifications.prepare_upload(f) },
+      reference: "some reference",
+      email_reply_to_id: ENV['EMAIL_REPLY_TO_ID'])
+  end
+
   test_notification_response_data_type(email_resp, 'email')
   email_resp
 end

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -9,6 +9,7 @@ require_relative "client/response_template"
 require_relative "client/template_collection"
 require_relative "client/template_preview"
 require_relative "client/uuid_validator"
+require_relative "client/helper_methods"
 require "forwardable"
 
 module Notifications
@@ -16,6 +17,7 @@ module Notifications
     attr_reader :speaker
 
     PRODUCTION_BASE_URL = "https://api.notifications.service.gov.uk".freeze
+    MAX_FILE_UPLOAD_SIZE = 2 * 1024 * 1024 # 2MB limit on uploaded documents
 
     extend Forwardable
     def_delegators :speaker, :service_id, :secret_token, :base_url, :base_url=

--- a/lib/notifications/client/helper_methods.rb
+++ b/lib/notifications/client/helper_methods.rb
@@ -1,0 +1,9 @@
+require "base64"
+
+module Notifications
+  def self.prepare_upload(file)
+    raise ArgumentError.new("Document is larger than 2MB") if file.size > Client::MAX_FILE_UPLOAD_SIZE
+
+    { file: Base64.strict_encode64(file.read) }
+  end
+end

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -120,7 +120,7 @@ module Notifications
       #   not successful
       def perform_request!(request)
         response = open(request)
-        if response.is_a?(Net::HTTPClientError)
+        if response.is_a?(Net::HTTPClientError) || response.is_a?(Net::HTTPServerError)
           raise RequestError.new(response)
         else
           JSON.parse(response.body)

--- a/lib/notifications/client/uuid_validator.rb
+++ b/lib/notifications/client/uuid_validator.rb
@@ -23,4 +23,3 @@ module Notifications
     end
   end
 end
-

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "2.8.0".freeze
+    VERSION = "2.9.0".freeze
   end
 end

--- a/spec/notifications/client/helper_methods_spec.rb
+++ b/spec/notifications/client/helper_methods_spec.rb
@@ -1,0 +1,31 @@
+require "base64"
+
+describe Notifications do
+  describe ".prepare_upload" do
+    it "encodes a File object" do
+      File.open('spec/test_files/test_pdf.pdf', 'rb') do |f|
+        encoded_content = Base64.strict_encode64(f.read)
+        f.rewind
+
+        result = Notifications.prepare_upload(f)
+        f.rewind
+
+        expect(result).to eq(file: encoded_content)
+        expect(Base64.strict_decode64(encoded_content)).to eq(f.read)
+      end
+    end
+
+    it "encodes a StringIO object" do
+      input_string = StringIO.new("My document to send")
+      expect(Notifications.prepare_upload(input_string)).to eq(file: "TXkgZG9jdW1lbnQgdG8gc2VuZA==")
+    end
+
+    it "raises an error when the file size is too large" do
+      File.open('spec/test_files/test_pdf.pdf', 'rb') do |file|
+        allow(file).to receive(:size).and_return(Notifications::Client::MAX_FILE_UPLOAD_SIZE + 1)
+
+        expect { Notifications.prepare_upload(file) }.to raise_error(ArgumentError, "Document is larger than 2MB")
+      end
+    end
+  end
+end

--- a/spec/notifications/client/precompiled_letter_spec.rb
+++ b/spec/notifications/client/precompiled_letter_spec.rb
@@ -1,3 +1,5 @@
+require "stringio"
+
 describe Notifications::Client do
   let(:client) { build :notifications_client }
   let(:uri) { URI.parse(Notifications::Client::PRODUCTION_BASE_URL) }
@@ -12,13 +14,24 @@ describe Notifications::Client do
         )
     end
 
-    it "hits the correct API endpoint with the encoded PDF file" do
+    it "hits the correct API endpoint with an encoded File object" do
       pdf_file = File.open('spec/test_files/test_pdf.pdf', 'rb')
       encoded_content = Base64.strict_encode64(pdf_file.read)
       pdf_file.rewind
 
       client.send_precompiled_letter('12345', pdf_file)
       pdf_file.close
+
+      expect(WebMock).to have_requested(:post, "https://#{uri.host}/v2/notifications/letter").
+        with(body: { reference: "12345", content: encoded_content })
+    end
+
+    it "hits the correct API endpoint with an encoded StringIO object" do
+      input_string = StringIO.new("My precompiled letter")
+      encoded_content = Base64.strict_encode64(input_string.read)
+      input_string.rewind
+
+      client.send_precompiled_letter('12345', input_string)
 
       expect(WebMock).to have_requested(:post, "https://#{uri.host}/v2/notifications/letter").
         with(body: { reference: "12345", content: encoded_content })

--- a/spec/notifications/client/request_errors_spec.rb
+++ b/spec/notifications/client/request_errors_spec.rb
@@ -1,13 +1,10 @@
 describe Notifications::Client do
   let(:client) { build :notifications_client }
+  let(:uri) { URI.parse(Notifications::Client::PRODUCTION_BASE_URL) }
 
   describe "authorisation error" do
     let(:error_response) {
       attributes_for(:client_request_error)[:body]
-    }
-
-    let(:uri) {
-      URI.parse(Notifications::Client::PRODUCTION_BASE_URL)
     }
 
     before do
@@ -21,6 +18,25 @@ describe Notifications::Client do
     end
 
     it "raises exception" do
+      expect {
+        client.get_notification("1")
+      }.to raise_error(Notifications::Client::RequestError)
+    end
+  end
+
+  describe "server error" do
+    it "raises a Notifications::Client::RequestError" do
+      stub_request(
+        :get,
+        "https://#{uri.host}:#{uri.port}/v2/notifications/1"
+      ).to_return(
+        status: 503,
+        body: {
+                'status_code' => 503,
+                'errors' => ['error' => 'BadRequestError', 'message' => 'App error']
+              }.to_json
+      )
+
       expect {
         client.get_notification("1")
       }.to raise_error(Notifications::Client::RequestError)


### PR DESCRIPTION
* Added a helper method, `prepare_upload`, to allow users to send a document with an email
* Added error handling for server errors - we were only catching client errors before.
* Updated the documentation to include precompiled letters and sending documents by email and bumped the version.