### PR TITLE
Set postage when sending precompiled letters and add it to response schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
-## 2.11.0
+## 3.0.0
 
+* Changed response class for `send_precompiled_letter` request from `ResponseNotification` to a new response class: `ResponsePrecompiledLetter`. This may affect users sending precompiled letters.
 * Added an optional `postage` argument to `send_precompiled_letter` method, so users can specify postage when sending
 a precompiled letter via API.
 * Added postage to `Notification` class on the client.
-* Added new response class: `ResponsePrecompiledLetter`, which makes response object for precompiled letters different
-class to other notification response objects.
 
 ## 2.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.11.0
+
+* Added an optional `postage` argument to `post_precompiled_letter` method and `send_precompiled_letter` that calls it.
+* Added postage to `ResponseNotification` and to `Notification` class on the client.
+
 ## 2.10.0
 
 * Added subclasses of the `RequestError` class to handle specific types of errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.11.0
 
-* Added an optional `postage` argument to `post_precompiled_letter` method and `send_precompiled_letter` that calls it.
+* Added an optional `postage` argument to `send_precompiled_letter` method, so users can specify postage when sending
+a precompiled letter via API.
 * Added postage to `Notification` class on the client.
 * Added new response class: `ResponsePrecompiledLetter`, which makes response object for precompiled letters different
 class to other notification response objects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 2.11.0
 
 * Added an optional `postage` argument to `post_precompiled_letter` method and `send_precompiled_letter` that calls it.
-* Added postage to `ResponseNotification` and to `Notification` class on the client.
+* Added postage to `Notification` class on the client.
+* Added new response class: `ResponsePrecompiledLetter`, which makes response object for precompiled letters different
+class to other notification response objects.
 
 ## 2.10.0
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -401,6 +401,11 @@ File.open("path/to/pdf_file", "rb") do |pdf_file|
 end
 ```
 
+#### postage (optional)
+
+You can select first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
+
+
 ### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client:ResponseNotification` object. In the example shown in the [Method section](/ruby.html#send-a-pre-compiled-letter-method), the object is named `precompiled_letter`.
@@ -411,6 +416,7 @@ You can then call different methods on this object to return the requested infor
 |:---|:---|:---|
 |`precompiled_letter.id`|Notification UUID|String|
 |`precompiled_letter.reference`|`reference` argument|String|
+|`precompiled_letter.postage`|`postage` argument|String or nil|
 |`precompiled_letter.content`|Always `nil`|nil|
 |`precompiled_letter.template`|Always `nil`|nil|
 |`precompiled_letter.uri`|Always `nil`|nil|
@@ -426,6 +432,7 @@ If the request is not successful, the client returns a `Notifications::Client::R
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Letter content is not a valid PDF"`<br>`]}`|`BadRequestError`|PDF file format is required|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|`BadRequestError`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "reference is a required property"`<br>`}]`|`BadRequestError`|Add a `reference` argument to the method call|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "postage invalid. It must be either first or second."`<br>`}]`|Change the value of `postage` argument in the method call to either 'first' or 'second'|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Service is not allowed to send precompiled letters"`<br>`}]`|`BadRequestError`|Contact the GOV.UK Notify team|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type live of 10 requests per 20 seconds"`<br>`}]`|`RateLimitError`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (50) for today"`<br>`}]`|`RateLimitError`|Refer to [service limits](#service-limits) for the limit number|

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -403,7 +403,7 @@ end
 
 #### postage (optional)
 
-You can select first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
+You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
 
 
 ### Response
@@ -416,7 +416,7 @@ You can then call different methods on this object to return the requested infor
 |:---|:---|:---|
 |`precompiled_letter.id`|Notification UUID|String|
 |`precompiled_letter.reference`|`reference` argument|String|
-|`precompiled_letter.postage`|`postage` argument|String or nil|
+|`precompiled_letter.postage`|`postage` argument|String|
 
 
 ### Error codes
@@ -430,7 +430,7 @@ If the request is not successful, the client returns a `Notifications::Client::R
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Letter content is not a valid PDF"`<br>`]}`|`BadRequestError`|PDF file format is required|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|`BadRequestError`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "reference is a required property"`<br>`}]`|`BadRequestError`|Add a `reference` argument to the method call|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "postage invalid. It must be either first or second."`<br>`}]`|Change the value of `postage` argument in the method call to either 'first' or 'second'|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "postage invalid. It must be either first or second."`<br>`}]`|`BadRequestError`|Change the value of `postage` argument in the method call to either 'first' or 'second'|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Service is not allowed to send precompiled letters"`<br>`}]`|`BadRequestError`|Contact the GOV.UK Notify team|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type live of 10 requests per 20 seconds"`<br>`}]`|`RateLimitError`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (50) for today"`<br>`}]`|`RateLimitError`|Refer to [service limits](#service-limits) for the limit number|
@@ -514,6 +514,7 @@ You can then call different methods on this object to return the requested infor
 |`response.line_5`|Recipient address line 5 of the address (letter only)|String|
 |`response.line_6`|Recipient address line 6 of the address (letter only)|String|
 |`response.postcode`|Recipient postcode (letter only)|String|
+|`response.postage`|Postage class of the notification sent (letter only)|String|
 |`response.type`|Type of notification sent (sms, email or letter)|String|
 |`response.status`|Notification status (sending / delivered / permanent-failure / temporary-failure / technical-failure)|String|
 |`response.template`|Template UUID|String|

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -408,7 +408,7 @@ You can select first or second class postage for your precompiled letter. Set th
 
 ### Response
 
-If the request to the client is successful, the client returns a `Notifications::Client:ResponseNotification` object. In the example shown in the [Method section](/ruby.html#send-a-pre-compiled-letter-method), the object is named `precompiled_letter`.
+If the request to the client is successful, the client returns a `Notifications::Client:ResponsePrecompiledLetter` object. In the example shown in the [Method section](/ruby.html#send-a-pre-compiled-letter-method), the object is named `precompiled_letter`.
 
 You can then call different methods on this object to return the requested information.
 
@@ -417,9 +417,7 @@ You can then call different methods on this object to return the requested infor
 |`precompiled_letter.id`|Notification UUID|String|
 |`precompiled_letter.reference`|`reference` argument|String|
 |`precompiled_letter.postage`|`postage` argument|String or nil|
-|`precompiled_letter.content`|Always `nil`|nil|
-|`precompiled_letter.template`|Always `nil`|nil|
-|`precompiled_letter.uri`|Always `nil`|nil|
+
 
 ### Error codes
 

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -159,8 +159,8 @@ def test_notification_response_data_type(notification, message_type)
 
   if message_type == 'precompiled_letter'
     field_should_not_be_nil(expected_fields_in_precompiled_letter_response, notification, 'send_precompiled_letter')
-    if notification.send(:"postage") != "first"
-      p "Postage should be set to 'first' for precompiled letter sending test. Right now it is set to #{notification[:postage]}"
+    if notification.postage != "first"
+      p "Postage should be set to 'first' for precompiled letter sending test. Right now it is set to #{notification.postage}"
       exit 1
     end
     return

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -148,7 +148,7 @@ def test_send_precompiled_letter_endpoint(client)
 end
 
 def test_notification_response_data_type(notification, message_type)
-  unless notification.is_a?(Notifications::Client::ResponseNotification)
+  unless notification.is_a?(Notifications::Client::ResponseNotification) || (notification.is_a?(Notifications::Client::ResponsePrecompiledLetter) && message_type == "precompiled_letter")
     p 'failed ' + message_type + ' response is not a Notifications::Client::ResponseNotification'
     exit 1
   end

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -139,7 +139,7 @@ end
 
 def test_send_precompiled_letter_endpoint(client)
   precompiled_letter_resp = File.open('spec/test_files/test_pdf.pdf', 'rb') do |file|
-    client.send_precompiled_letter("some reference", file)
+    client.send_precompiled_letter("some reference", file, "first")
   end
 
   test_notification_response_data_type(precompiled_letter_resp, 'precompiled_letter')
@@ -159,6 +159,10 @@ def test_notification_response_data_type(notification, message_type)
 
   if message_type == 'precompiled_letter'
     field_should_not_be_nil(expected_fields_in_precompiled_letter_response, notification, 'send_precompiled_letter')
+    if notification.send(:"postage") != "first"
+      p "Postage should be set to 'first' for precompiled letter sending test. Right now it is set to #{notification[:postage]}"
+      exit 1
+    end
     return
   end
 
@@ -255,7 +259,8 @@ end
 
 def expected_fields_in_precompiled_letter_response
   %w(id
-     reference)
+     reference
+     postage)
 end
 
 def expected_fields_in_email_content
@@ -297,7 +302,8 @@ def expected_fields_in_email_notification_that_are_nil
      line_5
      line_6
      postcode
-     created_by_name)
+     created_by_name
+     postage)
 end
 
 def expected_fields_in_sms_notification
@@ -321,7 +327,8 @@ def expected_fields_in_sms_notification_that_are_nil
      line_6
      postcode
      subject
-     created_by_name)
+     created_by_name
+     postage)
 end
 
 def expected_fields_in_letter_notification
@@ -336,6 +343,7 @@ def expected_fields_in_letter_notification
     line_2
     postcode
     created_at
+    postage
   )
 end
 
@@ -363,6 +371,7 @@ def expected_fields_in_precompiled_letter_notification
     subject
     template
     type
+    postage
   )
 end
 

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -2,6 +2,7 @@ require_relative "client/version"
 require_relative "client/speaker"
 require_relative "client/notification"
 require_relative "client/response_notification"
+require_relative "client/response_precompiled_letter"
 require_relative "client/notifications_collection"
 require_relative "client/received_text"
 require_relative "client/received_text_collection"
@@ -59,9 +60,9 @@ module Notifications
     # @param reference [String]
     # @param pdf_file [File]
     # @see Notifications::Client::Speaker#post_precompiled_letter
-    # @return [ResponseNotification]
+    # @return [ResponsePrecompiledLetter]
     def send_precompiled_letter(reference, pdf_file, postage = nil)
-      ResponseNotification.new(
+      ResponsePrecompiledLetter.new(
         speaker.post_precompiled_letter(reference, pdf_file, postage)
       )
     end

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -60,9 +60,9 @@ module Notifications
     # @param pdf_file [File]
     # @see Notifications::Client::Speaker#post_precompiled_letter
     # @return [ResponseNotification]
-    def send_precompiled_letter(reference, pdf_file)
+    def send_precompiled_letter(reference, pdf_file, postage = nil)
       ResponseNotification.new(
-        speaker.post_precompiled_letter(reference, pdf_file)
+        speaker.post_precompiled_letter(reference, pdf_file, postage)
       )
     end
 

--- a/lib/notifications/client/notification.rb
+++ b/lib/notifications/client/notification.rb
@@ -15,6 +15,7 @@ module Notifications
         line_5
         line_6
         postcode
+        postage
         type
         status
         template

--- a/lib/notifications/client/response_notification.rb
+++ b/lib/notifications/client/response_notification.rb
@@ -7,7 +7,6 @@ module Notifications
       content
       template
       uri
-      postage
     ).freeze
 
       attr_reader(*FIELDS)

--- a/lib/notifications/client/response_notification.rb
+++ b/lib/notifications/client/response_notification.rb
@@ -7,6 +7,7 @@ module Notifications
       content
       template
       uri
+      postage
     ).freeze
 
       attr_reader(*FIELDS)

--- a/lib/notifications/client/response_precompiled_letter.rb
+++ b/lib/notifications/client/response_precompiled_letter.rb
@@ -1,0 +1,19 @@
+module Notifications
+  class Client
+    class ResponsePrecompiledLetter
+      FIELDS = %i(
+      id
+      reference
+      postage
+    ).freeze
+
+      attr_reader(*FIELDS)
+
+      def initialize(notification)
+        FIELDS.each do |field|
+          instance_variable_set(:"@#{field}", notification.fetch(field.to_s, nil))
+        end
+      end
+    end
+  end
+end

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -102,9 +102,13 @@ module Notifications
       # @param reference [String] reference of the notification
       # @param pdf_file [File] PDF file opened for reading
       # @see #perform_request!
-      def post_precompiled_letter(reference, pdf_file)
+      def post_precompiled_letter(reference, pdf_file, postage = nil)
         content = Base64.strict_encode64(pdf_file.read)
         form_data = { reference: reference, content: content }
+
+        if postage != nil
+          form_data[:postage] = postage
+        end
 
         request = Net::HTTP::Post.new(
           "#{BASE_PATH}/letter",

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "2.11.0".freeze
+    VERSION = "3.0.0".freeze
   end
 end

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "2.10.0".freeze
+    VERSION = "2.11.0".freeze
   end
 end

--- a/spec/factories/client_notifications.rb
+++ b/spec/factories/client_notifications.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
         "line_5" => nil,
         "line_6" => nil,
         "postcode" => nil,
+        "postage" => nil,
         "type" => "sms",
         "status" => "delivered",
         "template" =>

--- a/spec/notifications/client/precompiled_letter_spec.rb
+++ b/spec/notifications/client/precompiled_letter_spec.rb
@@ -48,19 +48,15 @@ describe Notifications::Client do
         with(body: { reference: "12345", content: encoded_content, postage: 'first' })
     end
 
-    it "returns a ResponseNotification with an id, postage and reference" do
+    it "returns a ResponsePrecompiledLetter with an id, postage and reference" do
       response = File.open('spec/test_files/test_pdf.pdf', 'rb') do |file|
         client.send_precompiled_letter('my letter', file, 'first')
       end
 
-      expect(response).to be_a(Notifications::Client::ResponseNotification)
+      expect(response).to be_a(Notifications::Client::ResponsePrecompiledLetter)
       expect(response.id).to eq('12345')
       expect(response.reference).to eq('my letter')
       expect(response.postage).to eq('first')
-
-      expect(response.uri).to be_nil
-      expect(response.content).to be_nil
-      expect(response.template).to be_nil
     end
   end
 end

--- a/spec/notifications/client/precompiled_letter_spec.rb
+++ b/spec/notifications/client/precompiled_letter_spec.rb
@@ -8,7 +8,7 @@ describe Notifications::Client do
     before do
       stub_request(:post, "https://#{uri.host}/v2/notifications/letter").
         to_return(
-          body: { "id" => "12345", "reference" => "my letter" }.to_json,
+          body: { "id" => "12345", "reference" => "my letter", "postage" => "first" }.to_json,
           status: 201,
           headers: { "Content-Type" => "application/json" }
         )
@@ -37,14 +37,26 @@ describe Notifications::Client do
         with(body: { reference: "12345", content: encoded_content })
     end
 
-    it "returns a ResponseNotification with an id and reference" do
+    it "hits the correct API endpoint with postage" do
+      input_string = StringIO.new("My precompiled letter")
+      encoded_content = Base64.strict_encode64(input_string.read)
+      input_string.rewind
+
+      client.send_precompiled_letter('12345', input_string, 'first')
+
+      expect(WebMock).to have_requested(:post, "https://#{uri.host}/v2/notifications/letter").
+        with(body: { reference: "12345", content: encoded_content, postage: 'first' })
+    end
+
+    it "returns a ResponseNotification with an id, postage and reference" do
       response = File.open('spec/test_files/test_pdf.pdf', 'rb') do |file|
-        client.send_precompiled_letter('my letter', file)
+        client.send_precompiled_letter('my letter', file, 'first')
       end
 
       expect(response).to be_a(Notifications::Client::ResponseNotification)
       expect(response.id).to eq('12345')
       expect(response.reference).to eq('my letter')
+      expect(response.postage).to eq('first')
 
       expect(response.uri).to be_nil
       expect(response.content).to be_nil


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
Allow users to set postage when sending precompiled letters.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
