### PR TITLE
Add `html` field to template preview response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.0
+
+* Added `html` field to the TemplatePreview response, so users can see
+the rendered HTML of their email templates.
+
 ## 3.0.0
 
 * Changed response class for `send_precompiled_letter` request from `ResponseNotification` to a new response class: `ResponsePrecompiledLetter`. This may affect users sending precompiled letters.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -862,6 +862,7 @@ You can then call different methods on this object to return the requested infor
 |`response.body`|Template content|String|
 |`response.subject`|Template subject (email and letter)|String|
 |`response.type`|Template type (sms/email/letter)|String|
+|`response.html`|Body as rendered HTML (email only)|String|
 
 ### Error codes
 

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -246,7 +246,8 @@ def expected_fields_in_template_preview
   %w(id
      body
      version
-     type)
+     type
+     html)
 end
 
 def expected_fields_in_notification_response

--- a/lib/notifications/client/template_preview.rb
+++ b/lib/notifications/client/template_preview.rb
@@ -7,6 +7,7 @@ module Notifications
         body
         subject
         type
+        html
       ).freeze
 
       attr_reader(*FIELDS)

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "3.0.0".freeze
+    VERSION = "3.1.0".freeze
   end
 end

--- a/spec/factories/template_preview.rb
+++ b/spec/factories/template_preview.rb
@@ -11,7 +11,8 @@ FactoryBot.define do
         "body" => "Contents of template Mr Big Nose",
         "subject" => "Subject of the email",
         "version" => "2",
-        "type" => "email"
+        "type" => "email",
+        "html" => "<p>Contents of template Mr Big Nose</p>"
       }
     end
   end

--- a/spec/notifications/client/generate_template_preview_spec.rb
+++ b/spec/notifications/client/generate_template_preview_spec.rb
@@ -39,6 +39,7 @@ describe Notifications::Client do
       body
       subject
       version
+      html
     ).each do |field|
       it "expect to include #{field}" do
         expect(


### PR DESCRIPTION
## What problem does the pull request solve?

Adds support for a new field that the API is returning.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
