### PR TITLE
RequestError provides message as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0
+
+* `RequestError.message` now returns a string, not an array of hashes – see https://github.com/alphagov/notifications-ruby-client/pull/72
+
 ## 3.1.0
 
 * Added `html` field to the TemplatePreview response, so users can see

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -130,13 +130,13 @@ If the request is not successful, the client returns a `Notifications::Client::R
 
 |error.code|error.message|class|How to fix|
 |:---|:---|:---|:---|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`]}`|`BadRequestError`|Use the correct type of [API key](/ruby.html#api-keys)|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|`BadRequestError`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|`AuthError`|Check your system clock|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
-|`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds"`<br>`}]`|`RateLimitError`|Refer to [API rate limits](/ruby.html#api-rate-limits) for more information|
-|`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|`ClientError`|Refer to [service limits](/ruby.html#service-limits) for the limit number|
-|`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|`ServerError`|Notify was unable to process the request, resend your notification|
+|`400`|`BadRequestError: Can't send to this recipient using a team-only API key`|`BadRequestError`|Use the correct type of [API key](/ruby.html#api-keys)|
+|`400`|`BadRequestError: Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode`|`BadRequestError`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
+|`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`AuthError`|Check your system clock|
+|`403`|`AuthError: Invalid token: signature, api token not found`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
+|`429`|`RateLimitError: Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds`|`RateLimitError`|Refer to [API rate limits](/ruby.html#api-rate-limits) for more information|
+|`429`|`TooManyRequestsError: Exceeded send limits (LIMIT NUMBER) for today`|`ClientError`|Refer to [service limits](/ruby.html#service-limits) for the limit number|
+|`500`|`Exception: Internal server error`|`ServerError`|Notify was unable to process the request, resend your notification|
 
 ## Send an email
 
@@ -265,17 +265,17 @@ If the request is not successful, the client returns a `Notifications::Client::R
 
 |error.code|error.message|class|How to fix|
 |:--- |:---|:---|:---|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`]}`|`BadRequestError`|Use the correct type of [API key](/ruby.html#api-keys)|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|`BadRequestError`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported document type '{}'. Supported types are: {}"`<br>`}]`|`BadRequestError`|The document you upload must be a PDF file|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Document didn't pass the virus scan"`<br>`}]`|`BadRequestError`|The document you upload must be virus free|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Service is not allowed to send documents"`<br>`}]`|`BadRequestError`|Contact the GOV.UK Notify team|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|`AuthError`|Check your system clock|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
-|`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds"`<br>`}]`|`RateLimitError`|Refer to [API rate limits](/ruby.html#api-rate-limits) for more information|
-|`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|`RateLimitError`|Refer to [service limits](/ruby.html#service-limits) for the limit number|
-|`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|`ServerError`|Notify was unable to process the request, resend your notification|
-|-|`[{`<br>`"error": "ArgumentError",`<br>`"message": "Document is larger than 2MB")`<br>`}]`|-|Document size was too large, upload a smaller document|
+|`400`|`BadRequestError: Can't send to this recipient using a team-only API key`|`BadRequestError`|Use the correct type of [API key](/ruby.html#api-keys)|
+|`400`|`BadRequestError: Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode`|`BadRequestError`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
+|`400`|`BadRequestError: Unsupported document type '{}'. Supported types are: {}`|`BadRequestError`|The document you upload must be a PDF file|
+|`400`|`BadRequestError: Document didn't pass the virus scan`|`BadRequestError`|The document you upload must be virus free|
+|`400`|`BadRequestError: Service is not allowed to send documents`|`BadRequestError`|Contact the GOV.UK Notify team|
+|`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`AuthError`|Check your system clock|
+|`403`|`AuthError: Invalid token: signature, api token not found`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
+|`429`|`RateLimitError: Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds`|`RateLimitError`|Refer to [API rate limits](/ruby.html#api-rate-limits) for more information|
+|`429`|`TooManyRequestsError: Exceeded send limits (LIMIT NUMBER) for today`|`RateLimitError`|Refer to [service limits](/ruby.html#service-limits) for the limit number|
+|`500`|`Exception: Internal server error`|`ServerError`|Notify was unable to process the request, resend your notification|
+|-|`ArgumentError: Document is larger than 2MB")`|-|Document size was too large, upload a smaller document|
 
 ## Send a letter
 
@@ -371,14 +371,14 @@ If the request is not successful, the client returns a `Notifications::Client::R
 
 |error.code|error.message|class|How to fix|
 |:--- |:---|:---|:---|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|`BadRequestError`|Use the correct type of [API key](/ruby.html#api-keys)|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|`BadRequestError`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation address_line_1 is a required property"`<br>`}]`|`BadRequestError`|Ensure that your template has a field for the first line of the address, refer to [personalisation](/ruby.html#personalisation-required) for more information|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|`AuthError`|Check your system clock|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
-|`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds"`<br>`}]`|`RateLimitError`|Refer to [API rate limits](/ruby.html#api-rate-limits) for more information|
-|`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|`RateLimitError`|Refer to [service limits](/ruby.html#service-limits) for the limit number|
-|`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|`ServerError`|Notify was unable to process the request, resend your notification|
+|`400`|`BadRequestError: Cannot send letters with a team api key`|`BadRequestError`|Use the correct type of [API key](/ruby.html#api-keys)|
+|`400`|`BadRequestError: Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode`|`BadRequestError`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
+|`400`|`ValidationError: personalisation address_line_1 is a required property`|`BadRequestError`|Ensure that your template has a field for the first line of the address, refer to [personalisation](/ruby.html#personalisation-required) for more information|
+|`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`AuthError`|Check your system clock|
+|`403`|`AuthError: Invalid token: signature, api token not found`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
+|`429`|`RateLimitError: Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds`|`RateLimitError`|Refer to [API rate limits](/ruby.html#api-rate-limits) for more information|
+|`429`|`TooManyRequestsError: Exceeded send limits (LIMIT NUMBER) for today`|`RateLimitError`|Refer to [service limits](/ruby.html#service-limits) for the limit number|
+|`500`|`Exception: Internal server error`|`ServerError`|Notify was unable to process the request, resend your notification|
 
 ## Send a precompiled letter
 
@@ -426,13 +426,13 @@ If the request is not successful, the client returns a `Notifications::Client::R
 
 |error.status_code|error.message|class|How to fix|
 |:---|:---|:---|:---|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|`BadRequestError`|Use the correct type of [API key](#api-keys)|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Letter content is not a valid PDF"`<br>`]}`|`BadRequestError`|PDF file format is required|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|`BadRequestError`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "reference is a required property"`<br>`}]`|`BadRequestError`|Add a `reference` argument to the method call|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "postage invalid. It must be either first or second."`<br>`}]`|`BadRequestError`|Change the value of `postage` argument in the method call to either 'first' or 'second'|
-|`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type live of 10 requests per 20 seconds"`<br>`}]`|`RateLimitError`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
-|`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (50) for today"`<br>`}]`|`RateLimitError`|Refer to [service limits](#service-limits) for the limit number|
+|`400`|`BadRequestError: Cannot send letters with a team api key`|`BadRequestError`|Use the correct type of [API key](#api-keys)|
+|`400`|`BadRequestError: Letter content is not a valid PDF`|`BadRequestError`|PDF file format is required|
+|`400`|`BadRequestError: Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode`|`BadRequestError`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
+|`400`|`ValidationError: reference is a required property`|`BadRequestError`|Add a `reference` argument to the method call|
+|`400`|`ValidationError: postage invalid. It must be either first or second.`|`BadRequestError`|Change the value of `postage` argument in the method call to either 'first' or 'second'|
+|`429`|`RateLimitError: Exceeded rate limit for key type live of 10 requests per 20 seconds`|`RateLimitError`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
+|`429`|`TooManyRequestsError: Exceeded send limits (50) for today`|`RateLimitError`|Refer to [service limits](#service-limits) for the limit number|
 
 # Get message status
 
@@ -531,10 +531,10 @@ If the request is not successful, the client returns a `Notification::Client::Re
 
 |error.code|error.message|class|How to fix|
 |:---|:---|:---|:---|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|`BadRequestError`|Check the notification ID|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|`AuthError`|Check your system clock|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
-|`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|`NotFoundError`|Check the notification ID. This error occurs if the notification is more than 7 days old.|
+|`400`|`ValidationError: id is not a valid UUID`|`BadRequestError`|Check the notification ID|
+|`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`AuthError`|Check your system clock|
+|`403`|`AuthError: Invalid token: signature, api token not found`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
+|`404`|`NoResultFound: No result found`|`NotFoundError`|Check the notification ID. This error occurs if the notification is more than 7 days old.|
 
 ## Get the status of multiple messages
 
@@ -653,10 +653,10 @@ If the request is not successful, the client returns a `Notifications::Client::R
 
 |error.code|error.message|class|How to fix|
 |:---|:---|:---|:---|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "bad status is not one of [created, sending, sent, delivered, pending, failed, technical-failure, temporary-failure, permanent-failure, accepted, received]"`<br>`}]`|`BadRequestError`|Contact the GOV.UK Notify team|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "Template type is not one of [sms, email, letter]"`<br>`}]`|`BadRequestError`|Contact the GOV.UK Notify team|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|`AuthError`|Check your system clock|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
+|`400`|`ValidationError: bad status is not one of [created, sending, sent, delivered, pending, failed, technical-failure, temporary-failure, permanent-failure, accepted, received]`|`BadRequestError`|Contact the GOV.UK Notify team|
+|`400`|`ValidationError: Template type is not one of [sms, email, letter]`|`BadRequestError`|Contact the GOV.UK Notify team|
+|`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`AuthError`|Check your system clock|
+|`403`|`AuthError: Invalid token: signature, api token not found`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
 
 # Get a template
 
@@ -704,10 +704,10 @@ If the request is not successful, the client returns a `Notifications::Client::R
 
 |error.code|error.message|class|How to fix|
 |:---|:---|:---|:---|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|`BadRequestError`|Check the notification ID|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|`AuthError`|Check your system clock|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
-|`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No Result Found"`<br>`}]`|`NotFoundError`|Check your [template ID](/ruby.html#get-a-template-by-id-arguments-id-required)|
+|`400`|`ValidationError: id is not a valid UUID`|`BadRequestError`|Check the notification ID|
+|`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`AuthError`|Check your system clock|
+|`403`|`AuthError: Invalid token: signature, api token not found`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
+|`404`|`NoResultFound: No Result Found`|`NotFoundError`|Check your [template ID](/ruby.html#get-a-template-by-id-arguments-id-required)|
 
 ## Get a template by ID and version
 
@@ -755,10 +755,10 @@ If the request is not successful, the client returns a `Notifications::Client::R
 
 |error.code|error.message|class|How to fix|
 |:---|:---|:---|:---|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|`BadRequestError`|Check the notification ID|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|`AuthError`|Check your system clock|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
-|`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No Result Found"`<br>`}]`|`NotFoundError`|Check your [template ID](/ruby.html#get-a-template-by-id-and-version-arguments-id-required) and [version](/ruby.html#version-required)|
+|`400`|`ValidationError: id is not a valid UUID`|`BadRequestError`|Check the notification ID|
+|`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`AuthError`|Check your system clock|
+|`403`|`AuthError: Invalid token: signature, api token not found`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
+|`404`|`NoResultFound: No Result Found`|`NotFoundError`|Check your [template ID](/ruby.html#get-a-template-by-id-and-version-arguments-id-required) and [version](/ruby.html#version-required)|
 
 ## Get all templates
 
@@ -811,7 +811,7 @@ If the request is not successful, the client returns a `Notifications::Client::R
 
 |error.code|error.message|class|How to fix|
 |:---|:---|:---|:---|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "Template type is not one of [sms, email, letter]"`<br>`}]`|`BadRequestError`|Contact the Notify team|
+|`400`|`ValidationError: Template type is not one of [sms, email, letter]`|`BadRequestError`|Contact the Notify team|
 
 ## Generate a preview template
 
@@ -869,10 +869,10 @@ If the request is not successful, the client returns a `Notifications::Client::R
 
 |error.code|error.message|class|How to fix|
 |:---|:---|:---|:---|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Missing personalisation: [PERSONALISATION FIELD]"`<br>`}]`|`BadRequestError`|Check that the personalisation arguments in the method match the placeholder fields in the template|
-|`400`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|`BadRequestError`|Check the [template ID](/ruby.html#generate-a-preview-template-arguments-id-required)|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|`AuthError`|Check your system clock|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
+|`400`|`BadRequestError: Missing personalisation: [PERSONALISATION FIELD]`|`BadRequestError`|Check that the personalisation arguments in the method match the placeholder fields in the template|
+|`400`|`NoResultFound: No result found`|`BadRequestError`|Check the [template ID](/ruby.html#generate-a-preview-template-arguments-id-required)|
+|`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`AuthError`|Check your system clock|
+|`403`|`AuthError: Invalid token: signature, api token not found`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
 
 # Get received text messages
 
@@ -945,5 +945,5 @@ If the request is not successful, the client returns a `Notifications::Client::R
 
 |error.code|error.message|class|How to fix|
 |:---|:---|:---|:---|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|`AuthError`|Check your system clock|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|
+|`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`AuthError`|Check your system clock|
+|`403`|`AuthError: Invalid token: signature, api token not found`|`AuthError`|Use the correct API key. Refer to [API keys](/ruby.html#api-keys) for more information|

--- a/lib/notifications/client/request_error.rb
+++ b/lib/notifications/client/request_error.rb
@@ -1,21 +1,25 @@
 module Notifications
   class Client
     class RequestError < StandardError
-      attr_reader :code, :message
+      attr_reader :code, :body
 
       def initialize(response)
         @code = response.code
-        @message = message_from(response.body)
+        @body = parse_body(response.body)
       end
 
-      def to_s
-        "#{code} #{message}"
-      end
-
-      def message_from(body)
-        JSON.parse(body).fetch('errors')
+      def parse_body(body)
+        JSON.parse(body)
       rescue JSON::ParserError
         body
+      end
+
+      def message
+        return body if body.is_a?(String)
+
+        error_messages = body.fetch('errors')
+                             .map { |e| "#{e.fetch('error')}: #{e.fetch('message')}" }
+        error_messages.join(", ")
       end
     end
 

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "3.1.1".freeze
+    VERSION = "4.0.0".freeze
   end
 end

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "3.1.0".freeze
+    VERSION = "3.1.1".freeze
   end
 end

--- a/spec/notifications/client/request_errors_spec.rb
+++ b/spec/notifications/client/request_errors_spec.rb
@@ -8,13 +8,13 @@ describe Notifications::Client do
     stub_request(:get, url).to_return(status: code, body: body.to_json)
   end
 
-  def expect_error(error_class = Notifications::Client::RequestError)
-    expect { client.get_notification("1") }.to raise_error(error_class)
+  def expect_error(error_class = Notifications::Client::RequestError, message = nil)
+    expect { client.get_notification("1") }.to raise_error(error_class, message)
   end
 
-  shared_examples "raises an error" do |error_class|
+  shared_examples "raises an error" do |error_class, message|
     it "should raise a #{error_class}" do
-      expect_error(error_class)
+      expect_error(error_class, message)
     end
 
     it "should be a subclass of Notifications::Client::RequestError" do
@@ -55,6 +55,6 @@ describe Notifications::Client do
       })
     end
 
-    include_examples "raises an error", Notifications::Client::ServerError
+    include_examples "raises an error", Notifications::Client::ServerError, "BadRequestError: App error"
   end
 end


### PR DESCRIPTION
## What problem does the pull request solve?
Currently RequestError doesn't conform with [Ruby's `Exception`](https://ruby-doc.org/core-2.6.3/Exception.html#method-i-message) class which
expects message to be a string. When Raven, the Ruby client for Sentry,
processes the exception an error occur because it tries to [slice the string](https://github.com/getsentry/raven-ruby/blob/263a33b94d9a689d0fc5ba5c16bc92be9538e9fb/lib/raven/event.rb#L88
).

This changes RequestError from providing message as an array to providing
message as a string. We also remove the `to_s` method as it's no longer needed
since message is returning a string anyway.

This issues was discovered while using this gem in the [Content Publisher](https://github.com/alphagov/content-publisher) app.
Here is a screen grab from our Kibana logs to illustrate the error:
<img width="985" alt="kibana" src="https://user-images.githubusercontent.com/13434452/60352390-a5bde680-99bf-11e9-841f-88f01cde3c82.png">

We have tested this change in Content Publisher using this branch from my fork of this repo and it resolved the issue.

We've changed the patch version of this gem as we believe it to be a bug fix, but please let us know if you think otherwise.

## Checklist

- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
