### PR TITLE
Revert "remove old jenkins dockerfile"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,32 +32,45 @@ generate-env-file: ## Generate the environment file for running the tests inside
 
 .PHONY: prepare-docker-runner-image
 prepare-docker-runner-image: ## Prepare the Docker builder image
-	docker build \
-		-t ${DOCKER_BUILDER_IMAGE_NAME} \
-		.
+	make -C docker build
 
 .PHONY: build-with-docker
 build-with-docker: prepare-docker-runner-image ## Build inside a Docker container
 	docker run -i --rm \
 		--name "${DOCKER_CONTAINER_PREFIX}-build" \
 		-v "`pwd`:/var/project" \
+		-e http_proxy="${HTTP_PROXY}" \
+		-e HTTP_PROXY="${HTTP_PROXY}" \
+		-e https_proxy="${HTTPS_PROXY}" \
+		-e HTTPS_PROXY="${HTTPS_PROXY}" \
+		-e NO_PROXY="${NO_PROXY}" \
 		${DOCKER_BUILDER_IMAGE_NAME} \
 		make build
 
 .PHONY: test-with-docker
-test-with-docker: generate-env-file ## Run tests inside a Docker container
+test-with-docker: prepare-docker-runner-image generate-env-file ## Run tests inside a Docker container
 	docker run -i --rm \
 		--name "${DOCKER_CONTAINER_PREFIX}-test" \
 		-v "`pwd`:/var/project" \
+		-e http_proxy="${HTTP_PROXY}" \
+		-e HTTP_PROXY="${HTTP_PROXY}" \
+		-e https_proxy="${HTTPS_PROXY}" \
+		-e HTTPS_PROXY="${HTTPS_PROXY}" \
+		-e NO_PROXY="${NO_PROXY}" \
 		--env-file docker.env \
 		${DOCKER_BUILDER_IMAGE_NAME} \
 		make test
 
 .PHONY: integration-test-with-docker
-integration-test-with-docker: generate-env-file ## Run integration tests inside a Docker container
+integration-test-with-docker: prepare-docker-runner-image generate-env-file ## Run integration tests inside a Docker container
 	docker run -i --rm \
 		--name "${DOCKER_CONTAINER_PREFIX}-integration-test" \
 		-v "`pwd`:/var/project" \
+		-e http_proxy="${HTTP_PROXY}" \
+		-e HTTP_PROXY="${HTTP_PROXY}" \
+		-e https_proxy="${HTTPS_PROXY}" \
+		-e HTTPS_PROXY="${HTTPS_PROXY}" \
+		-e NO_PROXY="${NO_PROXY}" \
 		--env-file docker.env \
 		${DOCKER_BUILDER_IMAGE_NAME} \
 		make integration-test
@@ -68,7 +81,7 @@ clean-docker-containers: ## Clean up any remaining docker containers
 
 .PHONY: run-govuk-lint
 run-govuk-lint: ## Runs GOVUK-lint for Ruby
-	bundle exec govuk-lint-ruby lib spec bin/test_client
+	bundle exec govuk-lint-ruby lib spec bin/test_client 
 
 clean:
 	rm -rf vendor

--- a/bin/generate_docker_env.sh
+++ b/bin/generate_docker_env.sh
@@ -27,7 +27,3 @@ env_vars=(
 for env_var in "${env_vars[@]}"; do
     echo "${env_var}=${!env_var}" >> docker.env
 done
-
-echo BUNDLE_PATH="/var/project/vendor/bundle" >> docker.env
-echo BUNDLE_BIN="/var/project/vendor/bin" >> docker.env
-echo BUNDLE_APP_CONFIG="/var/project/.bundle" >> docker.env

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM ruby:2.4-slim
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+
+RUN \
+	echo "Install Debian packages" \
+	&& ([ -z "$HTTP_PROXY" ] || echo "Acquire::http::Proxy \"${HTTP_PROXY}\";" > /etc/apt/apt.conf.d/99HttpProxy) \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		gcc \
+		make \
+		curl \
+		git \
+	&& echo "Clean up" \
+	&& rm -rf /var/lib/apt/lists/* /tmp/*
+
+ENV PATH=/var/project/vendor/bin:$PATH \
+    BUNDLE_PATH="/var/project/vendor/bundle" \
+    BUNDLE_BIN="/var/project/vendor/bin" \
+    BUNDLE_APP_CONFIG="/var/project/.bundle"
+
+
+WORKDIR /var/project

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,16 @@
+.DEFAULT_GOAL := help
+SHELL := /bin/bash
+
+.PHONY: help
+help:
+	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: build
+build:
+	docker pull `grep "FROM " Dockerfile | cut -d ' ' -f 2` || true
+	docker build \
+		--build-arg HTTP_PROXY="${HTTP_PROXY}" \
+		--build-arg HTTPS_PROXY="${HTTP_PROXY}" \
+		--build-arg NO_PROXY="${NO_PROXY}" \
+		-t govuk/notify-ruby-client-builder \
+		.


### PR DESCRIPTION
This reverts commit 68c5fc27a7ad007fe8101c1637227f8ead0c3a06.

We can't remove the old dockerfile and make commands as jenkins still calls `run-ruby-client-integration-tests` on deploy of api/admin (and merge of ruby client). 

The old dockerfile has proxy settings that are needed on jenkins

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
