### PR TITLE
Expose exception message via `#to_s`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.1
+
+* Exceptions now return the error message when calling `#to_s` on them. This will make services like Sentry correctly display the full error description.
+
 ## 5.1.0
 
 * Added new `get_pdf_for_letter` method

--- a/lib/notifications/client/request_error.rb
+++ b/lib/notifications/client/request_error.rb
@@ -6,7 +6,10 @@ module Notifications
       def initialize(response)
         @code = response.code
         @body = parse_body(response.body)
+        super(build_message)
       end
+
+    private
 
       def parse_body(body)
         JSON.parse(body)
@@ -14,7 +17,7 @@ module Notifications
         body
       end
 
-      def message
+      def build_message
         return body if body.is_a?(String)
 
         error_messages = body.fetch('errors')

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "5.1.0".freeze
+    VERSION = "5.1.1".freeze
   end
 end

--- a/spec/notifications/client/request_errors_spec.rb
+++ b/spec/notifications/client/request_errors_spec.rb
@@ -57,4 +57,20 @@ describe Notifications::Client do
 
     include_examples "raises an error", Notifications::Client::ServerError, "BadRequestError: App error"
   end
+
+  describe "#message" do
+    before do
+      stub_error_request(401, body: {
+        'status_code' => 401,
+        'errors' => ['error' => 'BadRequestError', 'message' => 'Can’t send to this recipient using a team-only API key']
+      })
+    end
+
+    it "returns the message" do
+      expect { client.get_notification('1') }.to raise_error do |error|
+        expect(error.to_s).to eql('BadRequestError: Can’t send to this recipient using a team-only API key')
+        expect(error.message).to eql('BadRequestError: Can’t send to this recipient using a team-only API key')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

Exceptions in Ruby return the exception message when calling `#to_s` on it:

```
> irb
irb(main):001:0> StandardError.new("Hi").to_s
=> "Hi"
```

Because this is default behaviour, libraries sometimes depend on `to_s` to get a readable version of the exception message. For example, the Sentry client does it to give the exception a name:

https://github.com/getsentry/raven-ruby/blob/065cf973cb0ad3672d0d213e80b6e8a9a8e6f8cb/lib/raven/event.rb#L144

Currently, Sentry reports do not show the error message set when raising the exception - it only displays `Notifications::Client::BadRequestError`:

<img width="1229" alt="Screenshot 2020-01-06 at 11 53 26" src="https://user-images.githubusercontent.com/233676/71816636-29494600-307b-11ea-8f88-a25b1fd0427b.png">

This is because we’re [only defining `RequestError#message`](https://github.com/alphagov/notifications-ruby-client/blob/446923820d5133960d74eba6950f6c01168a3ea7/lib/notifications/client/request_error.rb#L17-L24). This is apparently not the same as initialising an exception with a message, as you can see here:

```rb
> be rails c
Loading development environment (Rails 6.0.2.1)
[1] pry(main)>
Notifications::Client::BadRequestError.new(OpenStruct.new(code: "hey", body: {errors: [{error: "BadRequestError", message: "Can’t send to this recipient using a team-only API key"}] }.to_json )).to_s
=> "Notifications::Client::BadRequestError"
[2] pry(main)>
Notifications::Client::BadRequestError.new(OpenStruct.new(code: "hey", body: {errors: [{error: "BadRequestError", message: "Can’t send to this recipient using a team-only API key"}] }.to_json )).message 
=> "BadRequestError: Can’t send to this recipient using a team-only API key"
```

The issue was introduced in https://github.com/alphagov/notifications-ruby-client/pull/73 / https://github.com/alphagov/notifications-ruby-client/pull/72, which removed the explicit `to_s` method.

This commit fixes the issue by constructing the message in the constructor. Note that we’ve renamed the `message` method, but calling `e.message` still works because it’s part of the exception interface. 

Another option would be to add the `to_s` method back (like we experimented with in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1024), but this solution seems the most Ruby-esque and relies on less knowledge of Exception internals.

After https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1024, the exceptions are properly reported:

| Before | After |
| --- | --- |
| <img width="1322" alt="Screenshot 2020-01-06 at 20 44 21" src="https://user-images.githubusercontent.com/233676/71847659-5ae6ff00-30c5-11ea-93c9-03c221d421a9.png"> | <img width="1208" alt="Screenshot 2020-01-06 at 20 05 21" src="https://user-images.githubusercontent.com/233676/71847613-3a1ea980-30c5-11ea-8213-3e1d10dd667b.png"> |


This change is backwards compatible.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
