### PR TITLE
Expose exception message via `#to_s`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.1
+
+* Exceptions now return the error message when calling `#to_s` on them. This will make services like Sentry correctly display the full error description.
+
 ## 5.1.0
 
 * Added new `get_pdf_for_letter` method

--- a/lib/notifications/client/request_error.rb
+++ b/lib/notifications/client/request_error.rb
@@ -6,7 +6,10 @@ module Notifications
       def initialize(response)
         @code = response.code
         @body = parse_body(response.body)
+        super(build_message)
       end
+
+    private
 
       def parse_body(body)
         JSON.parse(body)
@@ -14,7 +17,7 @@ module Notifications
         body
       end
 
-      def message
+      def build_message
         return body if body.is_a?(String)
 
         error_messages = body.fetch('errors')

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "5.1.0".freeze
+    VERSION = "5.1.1".freeze
   end
 end

--- a/spec/notifications/client/request_errors_spec.rb
+++ b/spec/notifications/client/request_errors_spec.rb
@@ -57,4 +57,20 @@ describe Notifications::Client do
 
     include_examples "raises an error", Notifications::Client::ServerError, "BadRequestError: App error"
   end
+
+  describe "#message" do
+    before do
+      stub_error_request(401, body: {
+        'status_code' => 401,
+        'errors' => ['error' => 'BadRequestError', 'message' => 'Can’t send to this recipient using a team-only API key']
+      })
+    end
+
+    it "returns the message" do
+      expect { client.get_notification('1') }.to raise_error do |error|
+        expect(error.to_s).to eql('BadRequestError: Can’t send to this recipient using a team-only API key')
+        expect(error.message).to eql('BadRequestError: Can’t send to this recipient using a team-only API key')
+      end
+    end
+  end
 end

--- a/spec/notifications/client/request_errors_spec.rb
+++ b/spec/notifications/client/request_errors_spec.rb
@@ -69,7 +69,7 @@ describe Notifications::Client do
     it "returns the message" do
       expect { client.get_notification('1') }.to raise_error do |error|
         expect(error.to_s).to eql('BadRequestError: Can’t send to this recipient using a team-only API key')
-        expect(error.message).to eql('BadRequestError: Can’t send to this recipient using a team-only API key')
+        expect(error.message).to eql('Can’t send to this recipient using a team-only API key')
       end
     end
   end


### PR DESCRIPTION
Recreating @tijmenb's PR (https://github.com/alphagov/notifications-ruby-client/pull/89) to get concourse to run it.