### PR TITLE
rename document to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.2
+
+* Change filesize too big exception message to refer to files rather than documents.
+
 ## 5.1.1
 
 * Exceptions now return the error message when calling `#to_s` on them. This will make services like Sentry correctly display the full error description.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -238,11 +238,11 @@ The links are unique and unguessable. GOV.UK Notify cannot access or decrypt you
 1. Select __Edit__.
 1. Add a placeholder field to the email template using double brackets. For example:
 
-"Download your file at: ((link_to_document))"
+"Download your file at: ((link_to_file))"
 
 ### Upload your file
 
-The file you upload must be a PDF or CSV file smaller than 2MB. [Contact the GOV.UK Notify team](https://www.notifications.service.gov.uk/support/ask-question-give-feedback) if you need to send other file types.
+The file you upload must be a PDF, CSV, text file or Microsoft Word document smaller than 2MB. [Contact the GOV.UK Notify team](https://www.notifications.service.gov.uk/support/ask-question-give-feedback) if you need to send other file types.
 
 1. Pass the file object as an argument to the `Notifications.prepare_upload` helper method.
 1. Pass the result into the personalisation argument.
@@ -255,7 +255,7 @@ File.open("file.pdf", "rb") do |f|
     personalisation: {
       first_name: "Amala",
       application_date: "2018-01-01",
-      link_to_document: Notifications.prepare_upload(f),
+      link_to_file: Notifications.prepare_upload(f),
     }
 end
 ```
@@ -282,15 +282,15 @@ If the request is not successful, the client returns a `Notifications::Client::R
 |:--- |:---|:---|:---|
 |`400`|`BadRequestError: Can't send to this recipient using a team-only API key`|`BadRequestError`|Use the correct type of [API key](#api-keys)|
 |`400`|`BadRequestError: Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode`|`BadRequestError`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
-|`400`|`BadRequestError: Unsupported document type '{}'. Supported types are: {}`|`BadRequestError`|The document you upload must be a PDF file|
-|`400`|`BadRequestError: Document didn't pass the virus scan`|`BadRequestError`|The document you upload must be virus free|
+|`400`|`BadRequestError: Unsupported file type '(FILE TYPE)'. Supported types are: '(ALLOWED TYPES)'`|`BadRequestError`|Wrong file type. You can only upload .pdf, .csv, .txt, .doc or .docx files|
+|`400`|`BadRequestError: File did not pass the virus scan`|`BadRequestError`|The file contains a virus|
 |`400`|`BadRequestError: Service is not allowed to send documents`|`BadRequestError`|Contact the GOV.UK Notify team|
 |`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`AuthError`|Check your system clock|
 |`403`|`AuthError: Invalid token: signature, api token not found`|`AuthError`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`429`|`RateLimitError: Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds`|`RateLimitError`|Refer to [API rate limits](#api-rate-limits) for more information|
 |`429`|`TooManyRequestsError: Exceeded send limits (LIMIT NUMBER) for today`|`RateLimitError`|Refer to [service limits](#service-limits) for the limit number|
 |`500`|`Exception: Internal server error`|`ServerError`|Notify was unable to process the request, resend your notification|
-|-|`ArgumentError: Document is larger than 2MB")`|-|Document size was too large, upload a smaller document|
+|-|`ArgumentError: File is larger than 2MB")`|-|The file is too big. Files must be smaller than 2MB|
 
 ## Send a letter
 
@@ -708,7 +708,7 @@ If the request is not successful, the client throws a `Notifications::Client::Re
 |:---|:---|:---|:---|
 |`400`|`ValidationError: id is not a valid UUID`|`BadRequestError`|Check the notification ID|
 |`400`|`PDFNotReadyError: PDF not available yet, try again later`|`BadRequestError`|Wait for the notification to finish processing. This usually takes a few seconds|
-|`400`|`BadRequestError: Document did not pass the virus scan`|`BadRequestError`|You cannot retrieve the contents of a letter notification that contains a virus|
+|`400`|`BadRequestError: File did not pass the virus scan`|`BadRequestError`|You cannot retrieve the contents of a letter notification that contains a virus|
 |`400`|`BadRequestError: PDF not available for letters in technical-failure`|`BadRequestError`|You cannot retrieve the contents of a letter notification in technical-failure|
 |`400`|`ValidationError: Notification is not a letter`|`BadRequestError`|Check that you are looking up the correct notification|
 |`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`BadRequestError`|Check your system clock|

--- a/lib/notifications/client/helper_methods.rb
+++ b/lib/notifications/client/helper_methods.rb
@@ -2,7 +2,7 @@ require "base64"
 
 module Notifications
   def self.prepare_upload(file)
-    raise ArgumentError.new("Document is larger than 2MB") if file.size > Client::MAX_FILE_UPLOAD_SIZE
+    raise ArgumentError.new("File is larger than 2MB") if file.size > Client::MAX_FILE_UPLOAD_SIZE
 
     { file: Base64.strict_encode64(file.read) }
   end

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "5.1.1".freeze
+    VERSION = "5.1.2".freeze
   end
 end

--- a/spec/notifications/client/helper_methods_spec.rb
+++ b/spec/notifications/client/helper_methods_spec.rb
@@ -24,7 +24,7 @@ describe Notifications do
       File.open('spec/test_files/test_pdf.pdf', 'rb') do |file|
         allow(file).to receive(:size).and_return(Notifications::Client::MAX_FILE_UPLOAD_SIZE + 1)
 
-        expect { Notifications.prepare_upload(file) }.to raise_error(ArgumentError, "Document is larger than 2MB")
+        expect { Notifications.prepare_upload(file) }.to raise_error(ArgumentError, "File is larger than 2MB")
       end
     end
   end


### PR DESCRIPTION
karlify some of the content.

note: some of the error messages are staying the same (eg "Document didn't pass the virus scan") because we're not sure if people might be using those strings to try and handle errors automatically. They're controlled by the API so people won't be aware when it suddenly switches.

However, this PR does change the file size too big error, that should be okay as it's only going to change when they upgrade the client library itself

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
