### PR TITLE
Update Ruby version to 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-slim
+FROM ruby:2.6-slim
 
 RUN \
 	echo "Install Debian packages" \

--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,5 @@ publish-to-rubygems: ## Create gemspec file and publish to rubygems
 clean-docker-containers: ## Clean up any remaining docker containers
 	docker rm -f $(shell docker ps -q -f "name=${DOCKER_CONTAINER_PREFIX}") 2> /dev/null || true
 
-.PHONY: run-govuk-lint
-run-govuk-lint: ## Runs GOVUK-lint for Ruby
-	bundle exec govuk-lint-ruby lib spec bin/test_client
-
 clean:
 	rm -rf vendor

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-slim
+FROM ruby:2.6-slim
 
 ARG HTTP_PROXY
 ARG HTTPS_PROXY

--- a/notifications-ruby-client.gemspec
+++ b/notifications-ruby-client.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "webmock", "~> 3.4"
   spec.add_development_dependency "factory_bot", "~> 5.2"
-  spec.add_development_dependency "govuk-lint", "~> 3.8"
 end

--- a/notifications-ruby-client.gemspec
+++ b/notifications-ruby-client.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jwt", ">= 1.5", "< 3"
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 12.3"
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "webmock", "~> 3.4"
-  spec.add_development_dependency "factory_bot", "~> 4.10"
+  spec.add_development_dependency "factory_bot", "~> 5.2"
   spec.add_development_dependency "govuk-lint", "~> 3.8"
 end

--- a/spec/factories/client_request_errors.rb
+++ b/spec/factories/client_request_errors.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :client_request_error,
           class: Notifications::Client::RequestError do
-    code '403'
+    code { '403' }
     body do
       {
           'status_code' => 400,

--- a/spec/factories/notifications_client.rb
+++ b/spec/factories/notifications_client.rb
@@ -2,8 +2,7 @@ FactoryBot.define do
   factory :notifications_client,
           class: Notifications::Client do
     base_url { nil }
-    jwt_secret "test-key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
-
+    jwt_secret { "test-key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a" }
     initialize_with do
       new(jwt_secret, base_url)
     end
@@ -11,7 +10,7 @@ FactoryBot.define do
 
   factory :notifications_client_combined,
           class: Notifications::Client do
-    jwt_secret "test_key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
+    jwt_secret { "test_key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a" }
 
     initialize_with do
       new(jwt_secret)
@@ -21,7 +20,7 @@ FactoryBot.define do
   factory :notifications_client_combined_with_base_url,
           class: Notifications::Client do
     base_url { "http://example.com" }
-    jwt_secret "test_key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a"
+    jwt_secret { "test_key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a" }
 
     initialize_with do
       new(jwt_secret, base_url)
@@ -31,7 +30,7 @@ FactoryBot.define do
   factory :notifications_client_with_invalid_api_key,
           class: Notifications::Client do
     base_url { nil }
-    jwt_secret "test_key-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    jwt_secret { "test_key-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" }
 
     initialize_with do
       new(jwt_secret, base_url)


### PR DESCRIPTION
**Update Ruby version**
Ruby version 2.4 is no longer supported. Also upgraded some of the development dependencies and fixed some deprecated syntax in the tests as a result.

These changes shouldn't have any effect on users of the gem. Changing the version of Ruby only changes the version of Ruby we use to run the tests, it doesn't force users of the gem to have Ruby version 2.6 installed.

**Remove `govuk-lint` development dependency**
This dependency is deprecated, and also wasn't being used. We can upgrade to the replacement, `rubocop-govuk`, but there are a lot of changes that it suggests, so it's better to look at this separately.