### PR TITLE
Rename whitelist to guest list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ export SMS_TEMPLATE_ID="valid sms_template_id"
 export LETTER_TEMPLATE_ID="valid letter_template_id"
 export EMAIL_REPLY_TO_ID="valid email reply to id"
 export SMS_SENDER_ID="valid sms_sender_id - to test sending to a receiving number, so needs to be a valid number"
-export API_SENDING_KEY="API_whitelist_key for sending a SMS to a receiving number"
+export API_SENDING_KEY="API_team_key for sending a SMS to a receiving number"
 export INBOUND_SMS_QUERY_KEY="API_test_key to get received text messages"
 ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -127,7 +127,7 @@ You can then call different methods on this object:
 
 If you are using the [test API key](#test), all your messages come back with a `delivered` status.
 
-All messages sent using the [team and whitelist](#team-and-whitelist) or [live](#live) keys appear on your GOV.UK Notify dashboard.
+All messages sent using the [team and guest list](#team-and-guest-list) or [live](#live) keys appear on your GOV.UK Notify dashboard.
 
 ### Error codes
 


### PR DESCRIPTION
We’re renaming the ‘Team and whitelist’ key in https://github.com/alphagov/notifications-admin/pull/3479

This commit updates the documentation to match.