### PR TITLE
Add ability to pass options to the http client

### DIFF
--- a/spec/factories/notifications_client.rb
+++ b/spec/factories/notifications_client.rb
@@ -2,9 +2,10 @@ FactoryBot.define do
   factory :notifications_client,
           class: Notifications::Client do
     base_url { nil }
+    http_opts { nil }
     jwt_secret { "test-key-fa80e418-ff49-445c-a29b-92c04a181207-7aaec57c-2dc9-4d31-8f5c-7225fe79516a" }
     initialize_with do
-      new(jwt_secret, base_url)
+      new(jwt_secret, base_url, http_opts)
     end
   end
 

--- a/spec/notifications/client/speaker_spec.rb
+++ b/spec/notifications/client/speaker_spec.rb
@@ -24,4 +24,45 @@ describe Notifications::Client do
       ).to eq(service_id)
     end
   end
+
+  context 'options passed to the http client' do
+    let(:client) { build :notifications_client, http_opts: options }
+    let(:http_options) { client.speaker.http_opts }
+
+    context 'with no additional options' do
+      let(:options) { nil }
+
+      it 'uses the defaults' do
+        expect(
+          http_options
+        ).to eq(Notifications::Client::Speaker::DEFAULT_HTTP_OPTS)
+      end
+    end
+
+    context 'with additional options' do
+      let(:options) { { read_timeout: 80, ssl_timeout: 10 } }
+
+      it 'merges the options into the defaults' do
+        expect(
+          http_options
+        ).to eq(
+          open_timeout: 60, read_timeout: 80, ssl_timeout: 10
+        )
+      end
+    end
+  end
+
+  context 'configuration of the http request' do
+    let(:response_double) { double(body: '{}') }
+
+    it 'configures the http client' do
+      expect(
+        Net::HTTP
+      ).to receive(:start).with(
+        'api.notifications.service.gov.uk', 443, :ENV, { open_timeout: 60, read_timeout: 60, use_ssl: true }
+      ).and_return(response_double)
+
+      client.speaker.post('email', {})
+    end
+  end
 end


### PR DESCRIPTION
We've found out when there is an increased latency with Notify or, more precisely with some of their upstream services (like, in particular Amazon S3 if attaching documents) the default `Net::HTTP` 60 seconds read timeout is not enough and the request is forcibly closed by the client.

This has a series of problems, the main one being that although the client closed the request, it seems like the email gets sent.

If we don't receive a successful response from Notify API we consider this a failed request and re-enqueue the email to be retried automatically a few seconds later, which in turns can again timeout on the client side, but not on the server side, which will manage to send the email.
In the end, multiple, duplicated emails are sent.

Long story short, we want to be able to configure a custom, higher read timeout to minimise where possible these latency issues.

Instead of forcing a higher time out for all users of this gem, I considered it would be better to let this as it is now (60 seconds is the default from Net::HTTP) and add the ability to pass custom timeouts (read/open) as well as other options, to the client.

How to test the timeout is being enforced, in a local console:

```ruby
# example with very low open timeout, will fail with Net::OpenTimeout (execution expired)
client = Notifications::Client.new('api-key', nil, open_timeout: 0.01)
client.send_email(email_address: "test@example.com", template_id: "uuid")

# example with very low read timeout, will fail with Net::ReadTimeout (Net::ReadTimeout)
client = Notifications::Client.new('api-key', nil, read_timeout: 0.01)
client.send_email(email_address: "test@example.com", template_id: "uuid")
```

Please note I've not updated the documentation or bumped the gem version as I wasn't sure if each PR goes into individual releases. But I can do that as part of this PR in a separate commit if preferred.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number (in `lib/notifications/client/version.rb`)