### PR TITLE
Add `is_csv` parameter to prepare_upload to fix csv doc download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.0
+
+* Add support for an optional `is_csv` parameter in the `prepare_upload()` function. This fixes a bug when sending a CSV file by email. This ensures that the file is downloaded as a CSV rather than a TXT file.
+
 ## 5.1.2
 
 * Change filesize too big exception message to refer to files rather than documents.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -263,6 +263,21 @@ File.open("file.pdf", "rb") do |f|
 end
 ```
 
+#### CSV Files
+
+Uploads for CSV files should use the `is_csv` parameter on the `prepare_upload()` helper method.  For example:
+
+```ruby
+File.open("file.csv", "rb") do |f|
+    ...
+    personalisation: {
+      first_name: "Amala",
+      application_date: "2018-01-01",
+      link_to_file: Notifications.prepare_upload(f, is_csv=true),
+    }
+end
+```
+
 ### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client:ResponseNotification` object. In the example shown in the [Method section](#send-an-email-method), the object is named `emailresponse`.

--- a/lib/notifications/client/helper_methods.rb
+++ b/lib/notifications/client/helper_methods.rb
@@ -1,9 +1,9 @@
 require "base64"
 
 module Notifications
-  def self.prepare_upload(file)
+  def self.prepare_upload(file, is_csv=false)
     raise ArgumentError.new("File is larger than 2MB") if file.size > Client::MAX_FILE_UPLOAD_SIZE
 
-    { file: Base64.strict_encode64(file.read) }
+    { file: Base64.strict_encode64(file.read), is_csv: is_csv }
   end
 end

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "5.1.2".freeze
+    VERSION = "5.2.0".freeze
   end
 end

--- a/spec/notifications/client/helper_methods_spec.rb
+++ b/spec/notifications/client/helper_methods_spec.rb
@@ -10,14 +10,19 @@ describe Notifications do
         result = Notifications.prepare_upload(f)
         f.rewind
 
-        expect(result).to eq(file: encoded_content)
+        expect(result).to eq(file: encoded_content, is_csv: false)
         expect(Base64.strict_decode64(encoded_content)).to eq(f.read)
       end
     end
 
     it "encodes a StringIO object" do
       input_string = StringIO.new("My document to send")
-      expect(Notifications.prepare_upload(input_string)).to eq(file: "TXkgZG9jdW1lbnQgdG8gc2VuZA==")
+      expect(Notifications.prepare_upload(input_string)).to eq(file: "TXkgZG9jdW1lbnQgdG8gc2VuZA==", is_csv: false)
+    end
+
+    it "allows is_csv to be set to true" do
+      input_string = StringIO.new("My document to send")
+      expect(Notifications.prepare_upload(input_string, true)).to eq(file: "TXkgZG9jdW1lbnQgdG8gc2VuZA==", is_csv: true)
     end
 
     it "raises an error when the file size is too large" do


### PR DESCRIPTION
Fixes the equivalent bug as https://github.com/alphagov/notifications-python-client/pull/165
so that CSV files are downloaded as CSV files rather than txt files

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
