### PR TITLE
Add letter_contact_block to Notifications::Client::Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.3.0
+
+* Added `letter_contact_block` as a new attribute of the `Notifications::Client::Template` class. This affects the responses from the `get_template_by_id`, `get_template_version` and `get_all_templates` methods.
+
 ## 5.2.0
 
 * Add support for an optional `is_csv` parameter in the `prepare_upload()` function. This fixes a bug when sending a CSV file by email. This ensures that the file is downloaded as a CSV rather than a TXT file.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -770,6 +770,7 @@ You can then call different methods on this object to return the requested infor
 |`response.version`|Template version|String|
 |`response.body`|Template content|String|
 |`response.subject`|Template subject (email and letter)|String|
+|`response.letter_contact_block`|Template letter contact block (letter)|String|
 
 ### Error codes
 
@@ -821,6 +822,7 @@ You can then call different methods on this object to return the requested infor
 |`response.version`|Template version|String|
 |`response.body`|Template content|String|
 |`response.subject`|Template subject (email and letter)|String|
+|`response.letter_contact_block`|Template letter contact block (letter)|String|
 
 ### Error codes
 
@@ -875,6 +877,7 @@ Once the client has returned a template array, you must then call the following 
 |`response.version`|Template version|String|
 |`response.body`|Template content|String|
 |`response.subject`|Template subject (email and letter)|String|
+|`response.letter_contact_block`|Template letter contact block (letter)|String|
 
 If no templates exist for a template type or there no templates for a service, the templates array will be empty.
 

--- a/lib/notifications/client/response_template.rb
+++ b/lib/notifications/client/response_template.rb
@@ -13,6 +13,7 @@ module Notifications
         version
         body
         subject
+        letter_contact_block
       ).freeze
 
       attr_reader(*FIELDS)

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "5.2.0".freeze
+    VERSION = "5.3.0".freeze
   end
 end

--- a/notifications-ruby-client.gemspec
+++ b/notifications-ruby-client.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "webmock", "~> 3.4"
-  spec.add_development_dependency "factory_bot", "~> 5.2"
+  spec.add_development_dependency "factory_bot", "~> 6.1"
 end

--- a/spec/factories/template_response.rb
+++ b/spec/factories/template_response.rb
@@ -9,13 +9,14 @@ FactoryBot.define do
       {
         "id" => "f163deaf-2d3f-4ec6-98fc-f23fa511518f",
         "name" => "My template name",
-        "type" => "email",
+        "type" => "letter",
         "created_at" => "2016-11-29T11:12:30.12354Z",
         "updated_at" => "2016-11-29T11:12:40.12354Z",
         "created_by" => "jane.doe@gmail.com",
         "body" => "Contents of template ((place_holder))",
-        "subject" => "Subject of the email",
-        "version" => "2"
+        "subject" => "Subject of the letter",
+        "version" => "2",
+        "letter_contact_block" => "The return address"
       }
     end
   end

--- a/spec/notifications/client/get_template_spec.rb
+++ b/spec/notifications/client/get_template_spec.rb
@@ -41,6 +41,7 @@ describe Notifications::Client do
       created_by
       subject
       version
+      letter_contact_block
     ).each do |field|
       it "expect to include #{field}" do
         expect(

--- a/spec/notifications/client/get_template_version_spec.rb
+++ b/spec/notifications/client/get_template_version_spec.rb
@@ -43,6 +43,7 @@ describe Notifications::Client do
       created_by
       subject
       version
+      letter_contact_block
     ).each do |field|
       it "expect to include #{field}" do
         expect(


### PR DESCRIPTION
This adds a new `letter_contact_block` attribute to the
`Notifications::Client::Template` class. `letter_contact_block` can be
`nil` or the contact block of a letter template and will now be returned
as part of the response from the `get_template_by_id`, `get_template_version`
and `get_all_templates` methods.