### PR TITLE
Adjust heading levels in DOCUMENTATION.md

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2,9 +2,9 @@
 
 This documentation is for developers interested in using the GOV.UK Notify Ruby client to send emails, text messages or letters.
 
-# Set up the client
+## Set up the client
 
-## Install the client
+### Install the client
 
 Run the following in the command line:
 
@@ -14,7 +14,7 @@ gem install 'notifications-ruby-client'
 
 Refer to the [client changelog](https://github.com/alphagov/notifications-ruby-client/blob/master/CHANGELOG.md) for the version number and the latest updates.
 
-## Create a new instance of the client
+### Create a new instance of the client
 
 Add this code to your application:
 
@@ -25,13 +25,13 @@ client = Notifications::Client.new(api_key)
 
 To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page. You can find more information in the [API keys](#api-keys) section of this documentation.
 
-# Send a message
+## Send a message
 
 You can use GOV.UK Notify to send text messages, emails or letters.
 
-## Send a text message
+### Send a text message
 
-### Method
+#### Method
 
 ```ruby
 smsresponse = client.send_sms(
@@ -40,9 +40,9 @@ smsresponse = client.send_sms(
 )
 ```
 
-### Arguments
+#### Arguments
 
-#### phone_number (required)
+##### phone_number (required)
 
 The phone number of the text message recipient. This can be a UK or international number. For example:
 
@@ -50,7 +50,7 @@ The phone number of the text message recipient. This can be a UK or internationa
 phone_number:"+447900900123"
 ```
 
-#### template_id (required)
+##### template_id (required)
 
 To find the template ID:
 
@@ -64,7 +64,7 @@ For example:
 template_id:"f33517ff-2a88-4f6e-b855-c550268ce08a"
 ```
 
-#### personalisation (optional)
+##### personalisation (optional)
 
 If a template has placeholder fields for personalised information such as name or reference number, you must provide their values in a hash. For example:
 
@@ -77,7 +77,7 @@ personalisation: {
 
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -87,7 +87,7 @@ reference: "your_reference_string"
 
 You can leave out this argument if you do not have a reference.
 
-#### sms_sender_id (optional)
+##### sms_sender_id (optional)
 
 A unique identifier of the sender of the text message notification.
 
@@ -111,7 +111,7 @@ sms_sender_id: "8e222534-7f05-4972-86e3-17c5d9f894e2"
 
 You can leave out this argument if your service only has one text message sender, or if you want to use the default sender.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client:ResponseNotification` object. In the example shown in the [Method section](#method), the object is named `smsresponse`.
 
@@ -129,7 +129,7 @@ If you are using the [test API key](#test), all your messages come back with a `
 
 All messages sent using the [team and guest list](#team-and-guest-list) or [live](#live) keys appear on your GOV.UK Notify dashboard.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client raises a `Notifications::Client::RequestError` exception (or a subclass), which contains a code:
 
@@ -143,9 +143,9 @@ If the request is not successful, the client raises a `Notifications::Client::Re
 |`429`|`TooManyRequestsError: Exceeded send limits (LIMIT NUMBER) for today`|`ClientError`|Refer to [service limits](#daily-limits) for the limit number|
 |`500`|`Exception: Internal server error`|`ServerError`|Notify was unable to process the request, resend your notification|
 
-## Send an email
+### Send an email
 
-### Method
+#### Method
 
 ```ruby
 emailresponse = client.send_email(
@@ -154,9 +154,9 @@ emailresponse = client.send_email(
 )
 ```
 
-### Arguments
+#### Arguments
 
-#### email_address (required)
+##### email_address (required)
 
 The email address of the recipient. For example:
 
@@ -164,7 +164,7 @@ The email address of the recipient. For example:
 email_address: "sender@something.com"
 ```
 
-#### template_id (required)
+##### template_id (required)
 
 To find the template ID:
 
@@ -178,7 +178,7 @@ For example:
 template_id: "f33517ff-2a88-4f6e-b855-c550268ce08a"
 ```
 
-#### personalisation (optional)
+##### personalisation (optional)
 
 If a template has placeholder fields for personalised information such as name or reference number, you must provide their values in a hash. For example:
 
@@ -191,7 +191,7 @@ personalisation: {
 
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -201,7 +201,7 @@ reference: "your_reference_string"
 
 You can leave out this argument if you do not have a reference.
 
-#### email_reply_to_id (optional)
+##### email_reply_to_id (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.
 
@@ -221,20 +221,20 @@ email_reply_to_id: '8e222534-7f05-4972-86e3-17c5d9f894e2'
 
 You can leave out this argument if your service only has one email reply-to address, or you want to use the default email address.
 
-## Send a file by email
+### Send a file by email
 
 To send a file by email, add a placeholder to the template then upload a file. The placeholder will contain a secure link to download the file.
 
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
 
-### Add contact details to the file download page
+#### Add contact details to the file download page
 
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Settings__ page.
 1. In the __Email__ section, select __Manage__ on the __Send files by email__ row.
 1. Enter the contact details you want to use, and select __Save__.
 
-### Add a placeholder to the template
+#### Add a placeholder to the template
 
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
@@ -243,7 +243,7 @@ The links are unique and unguessable. GOV.UK Notify cannot access or decrypt you
 
 "Download your file at: ((link_to_file))"
 
-### Upload your file
+#### Upload your file
 
 You can upload PDF, CSV, .odt, .txt and MS Word Document files. Your file must be smaller than 2MB. [Contact the GOV.UK Notify team](https://www.notifications.service.gov.uk/support/ask-question-give-feedback) if you need to send other file types.
 
@@ -263,7 +263,7 @@ File.open("file.pdf", "rb") do |f|
 end
 ```
 
-#### CSV Files
+##### CSV Files
 
 Uploads for CSV files should use the `is_csv` parameter on the `prepare_upload()` helper method.  For example:
 
@@ -278,7 +278,7 @@ File.open("file.csv", "rb") do |f|
 end
 ```
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client:ResponseNotification` object. In the example shown in the [Method section](#send-an-email-method), the object is named `emailresponse`.
 
@@ -292,7 +292,7 @@ You can then call different methods on this object to return the requested infor
 |`emailresponse.template`|Contains the `id`, `version` and `uri` of the template|Hash|
 |`emailresponse.uri`|Notification URL|String|
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client raises a `Notifications::Client::RequestError` exception (or a subclass), which contains a code:
 
@@ -310,7 +310,7 @@ If the request is not successful, the client raises a `Notifications::Client::Re
 |`500`|`Exception: Internal server error`|`ServerError`|Notify was unable to process the request, resend your notification|
 |-|`ArgumentError: File is larger than 2MB")`|-|The file is too big. Files must be smaller than 2MB|
 
-## Send a letter
+### Send a letter
 
 When you add a new service it will start in [trial mode](https://www.notifications.service.gov.uk/features/trial-mode). You can only send letters when your service is live.
 
@@ -320,7 +320,7 @@ To send Notify a request to go live:
 1. Go to the __Settings__ page.
 1. In the __Your service is in trial mode__ section, select __request to go live__.
 
-### Method
+#### Method
 
 ```ruby
 letterresponse = client.send_letter(
@@ -333,9 +333,9 @@ letterresponse = client.send_letter(
 )
 ```
 
-### Arguments
+#### Arguments
 
-#### template_id (required)
+##### template_id (required)
 
 To find the template ID:
 
@@ -349,7 +349,7 @@ For example:
 template_id: "f33517ff-2a88-4f6e-b855-c550268ce08a"
 ```
 
-#### personalisation (required)
+##### personalisation (required)
 
 The personalisation argument always contains the following parameters for the letter recipient’s address:
 
@@ -382,7 +382,7 @@ personalisation: {
 },
 ```
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -390,7 +390,7 @@ A unique identifier you can create if necessary. This reference identifies a sin
 reference: 'your_reference_string'
 ```
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client:ResponseNotification` object. In the example shown in the [Method section](#send-a-letter-method), the object is named `letterresponse`.
 
@@ -405,7 +405,7 @@ You can then call different methods on this object to return the requested infor
 |`letterresponse.uri`|Notification URL|String|
 
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client raises a `Notifications::Client::RequestError` exception (or a subclass), which contains a code:
 
@@ -422,19 +422,19 @@ If the request is not successful, the client raises a `Notifications::Client::Re
 |`429`|`TooManyRequestsError: Exceeded send limits (LIMIT NUMBER) for today`|`RateLimitError`|Refer to [service limits](#daily-limits) for the limit number.|
 |`500`|`Exception: Internal server error`|`ServerError`|Notify was unable to process the request, resend your notification.|
 
-## Send a precompiled letter
+### Send a precompiled letter
 
-### Method
+#### Method
 ```ruby
 precompiled_letter = client.send_precompiled_letter(reference, pdf_file)
 ```
 
-### Arguments
+#### Arguments
 
-#### reference (required)
+##### reference (required)
 A unique identifier you create. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
-#### pdf_file (required)
+##### pdf_file (required)
 
 The precompiled letter must be a PDF file which meets [the GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf).
 
@@ -444,12 +444,12 @@ File.open("path/to/pdf_file", "rb") do |pdf_file|
 end
 ```
 
-#### postage (optional)
+##### postage (optional)
 
 You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
 
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client:ResponsePrecompiledLetter` object. In the example shown in the [Method section](#send-a-precompiled-letter-method), the object is named `precompiled_letter`.
 
@@ -462,7 +462,7 @@ You can then call different methods on this object to return the requested infor
 |`precompiled_letter.postage`|`postage` argument|String|
 
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client raises a `Notifications::Client::RequestError` exception (or a subclass), which contains a code:
 
@@ -476,13 +476,13 @@ If the request is not successful, the client raises a `Notifications::Client::Re
 |`429`|`RateLimitError: Exceeded rate limit for key type live of 10 requests per 20 seconds`|`RateLimitError`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`429`|`TooManyRequestsError: Exceeded send limits (50) for today`|`RateLimitError`|Refer to [service limits](#daily-limits) for the limit number|
 
-# Get message status
+## Get message status
 
 Message status depends on the type of message you have sent.
 
 You can only get the status of messages that are 7 days old or newer.
 
-## Status - email
+### Status - email
 
 |Status|Information|
 |:---|:---|
@@ -491,7 +491,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Delivered|The message was successfully delivered.|
 |Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s inbox is full. You can try to send the message again."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again."|
 
-## Status - text message
+### Status - text message
 
 |Status|Information|
 |:---|:---|
@@ -502,7 +502,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Delivered|The message was successfully delivered.|
 |Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure."|
 
-## Status - letter
+### Status - letter
 
 |Status|information|
 |:---|:---|
@@ -510,7 +510,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Accepted|GOV.UK Notify has sent the letter to the provider to be printed.|
 |Received|The provider has printed and dispatched the letter.|
 
-## Status - precompiled letter
+### Status - precompiled letter
 
 |Status|information|
 |:---|:---|
@@ -518,26 +518,26 @@ You can only get the status of messages that are 7 days old or newer.
 |Virus scan failed|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |Validation failed|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf) for more information.|
 
-## Get the status of one message
+### Get the status of one message
 
 You can only get the status of messages that are 7 days old or newer.
 
-### Method
+#### Method
 
 ```ruby
 response = client.get_notification(id)
 ```
 
-### Arguments
+#### Arguments
 
-#### id (required)
+##### id (required)
 
 The ID of the notification. To find the notification ID, you can either:
 
 * check the response to the [original notification method call](#response)
 * [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client::Notification` object. In the example shown in the [Method section](#get-the-status-of-one-message-method), the object is named `response`.
 
@@ -567,7 +567,7 @@ You can then call different methods on this object to return the requested infor
 |`response.completed_at`|Date and time notification delivered or failed|String|
 |`response.created_by_name`|Name of sender if notification sent manually|String|
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client raises a `Notifications::Client::RequestError` exception (or a subclass), which contains a code:
 
@@ -578,13 +578,13 @@ If the request is not successful, the client raises a `Notifications::Client::Re
 |`403`|`AuthError: Invalid token: API key not found`|`AuthError`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`404`|`NoResultFound: No result found`|`NotFoundError`|Check the notification ID. This error occurs if the notification is more than 7 days old.|
 
-## Get the status of multiple messages
+### Get the status of multiple messages
 
 This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
 You can only get messages that are 7 days old or newer.
 
-### Method
+#### Method
 
 ```ruby
 args = {
@@ -600,11 +600,11 @@ You can leave out the `older_than` argument to get the 250 most recent messages.
 
 To get older messages, pass the ID of an older notification into the `older_than` argument. This returns the next 250 oldest messages from the specified notification ID.
 
-### Arguments
+#### Arguments
 
 You can leave out these arguments to ignore these filters.
 
-#### status (optional)
+##### status (optional)
 
 You can filter by each:
 
@@ -615,7 +615,7 @@ You can filter by each:
 
 You can leave out this argument to ignore this filter.
 
-#### templateType (optional)
+##### templateType (optional)
 
 You can filter by:
 
@@ -623,7 +623,7 @@ You can filter by:
 * `sms`
 * `letter`
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -631,7 +631,7 @@ A unique identifier you can create if necessary. This reference identifies a sin
 reference: 'your_reference_string'
 ```
 
-#### older_than (optional)
+##### older_than (optional)
 
 Input the ID of a notification into this argument. If you use this argument, the client returns the next 250 received notifications older than the given ID. For example:
 
@@ -643,7 +643,7 @@ If you leave out this argument, the client returns the most recent 250 notificat
 
 The client only returns notifications that are 7 days old or newer. If the notification specified in this argument is older than 7 days, the client returns an empty response.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client::NotificationsCollection` object. In the example shown in the [Method section](#get-the-status-of-multiple-messages-method), the object is named `response`.
 
@@ -681,7 +681,7 @@ If you call the `collection` method on this object to return a notification arra
 
 If the notification specified in the `older_than` argument is older than 7 days, the client returns an empty `collection` response.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client raises a `Notifications::Client::RequestError` exception (or a subclass), which contains a code:
 
@@ -692,9 +692,9 @@ If the request is not successful, the client raises a `Notifications::Client::Re
 |`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`AuthError`|Check your system clock|
 |`403`|`AuthError: Invalid token: API key not found`|`AuthError`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 
-## Get a PDF for a letter notification
+### Get a PDF for a letter notification
 
-### Method
+#### Method
 
 This returns the pdf contents of a letter notification.
 
@@ -704,20 +704,20 @@ pdf_file = client.get_pdf_for_letter(
 )
 ```
 
-### Arguments
+#### Arguments
 
-#### id (required)
+##### id (required)
 
 The ID of the notification. To find the notification ID, you can either:
 
 * check the response to the [original notification method call](#get-the-status-of-one-message-response)
 * [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page
 
-### Response
+#### Response
 
 If the request to the client is successful, the client will return a `string` containing the raw PDF data.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client raises a `Notifications::Client::RequestError` exception (or a subclass), which contains a code:
 
@@ -733,11 +733,11 @@ If the request is not successful, the client raises a `Notifications::Client::Re
 |`404`|`NoResultFound: No result found`|`BadRequestError`|Check the notification ID|
 
 
-# Get a template
+## Get a template
 
-## Get a template by ID
+### Get a template by ID
 
-### Method
+#### Method
 
 This returns the latest version of the template.
 
@@ -745,9 +745,9 @@ This returns the latest version of the template.
 response = client.get_template_by_id(id)
 ```
 
-### Arguments
+#### Arguments
 
-#### id (required)
+##### id (required)
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it. For example:
 
@@ -755,7 +755,7 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 'f33517ff-2a88-4f6e-b855-c550268ce08a'
 ```
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client::Template` object. In the example shown in the [Method section](#get-a-template-by-id-method), the object is named `response`.
 
@@ -774,7 +774,7 @@ You can then call different methods on this object to return the requested infor
 |`response.subject`|Template subject (email and letter)|String|
 |`response.letter_contact_block`|Template letter contact block (letter)|String|
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client raises a `Notifications::Client::RequestError` exception (or a subclass), which contains a code:
 
@@ -785,17 +785,17 @@ If the request is not successful, the client raises a `Notifications::Client::Re
 |`403`|`AuthError: Invalid token: API key not found`|`AuthError`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`404`|`NoResultFound: No Result Found`|`NotFoundError`|Check your [template ID](#get-a-template-by-id-arguments-id-required)|
 
-## Get a template by ID and version
+### Get a template by ID and version
 
-### Method
+#### Method
 
 ```ruby
 response = client.get_template_version(id, version)
 ```
 
-### Arguments
+#### Arguments
 
-#### id (required)
+##### id (required)
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it. For example:
 
@@ -803,11 +803,11 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 'f33517ff-2a88-4f6e-b855-c550268ce08a'
 ```
 
-#### version (required)
+##### version (required)
 
 The version number of the template.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client::Template` object. In the example shown in the [Method section](#get-a-template-by-id-and-version-method), the object is named `response`.
 
@@ -826,7 +826,7 @@ You can then call different methods on this object to return the requested infor
 |`response.subject`|Template subject (email and letter)|String|
 |`response.letter_contact_block`|Template letter contact block (letter)|String|
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client raises a `Notifications::Client::RequestError` exception (or a subclass), which contains a code:
 
@@ -837,9 +837,9 @@ If the request is not successful, the client raises a `Notifications::Client::Re
 |`403`|`AuthError: Invalid token: API key not found`|`AuthError`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`404`|`NoResultFound: No Result Found`|`NotFoundError`|Check your [template ID](#get-a-template-by-id-and-version-arguments-id-required) and [version](#version-required)|
 
-## Get all templates
+### Get all templates
 
-### Method
+#### Method
 
 This returns the latest version of all templates inside a collection object.
 
@@ -850,9 +850,9 @@ args = {
 response = client.get_all_templates(args)
 ```
 
-### Arguments
+#### Arguments
 
-#### type (optional)
+##### type (optional)
 
 If you do not use `type`, the client returns all templates. Otherwise you can filter by:
 
@@ -860,7 +860,7 @@ If you do not use `type`, the client returns all templates. Otherwise you can fi
 - `sms`
 - `letter`
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client::TemplateCollection` object. In the example shown in the [Method section](#get-all-templates-method), the object is named `response`.
 
@@ -883,7 +883,7 @@ Once the client has returned a template array, you must then call the following 
 
 If no templates exist for a template type or there no templates for a service, the templates array will be empty.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client raises a `Notifications::Client::RequestError` exception (or a subclass), which contains a code:
 
@@ -891,9 +891,9 @@ If the request is not successful, the client raises a `Notifications::Client::Re
 |:---|:---|:---|:---|
 |`400`|`ValidationError: Template type is not one of [sms, email, letter]`|`BadRequestError`|Contact the Notify team|
 
-## Generate a preview template
+### Generate a preview template
 
-### Method
+#### Method
 
 This generates a preview version of a template.
 
@@ -903,9 +903,9 @@ response = client.generate_template_preview(id)
 
 The parameters in the personalisation argument must match the placeholder fields in the actual template. The API notification client ignores any extra fields in the method.
 
-### Arguments
+#### Arguments
 
-#### id (required)
+##### id (required)
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it. For example:
 
@@ -913,7 +913,7 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 'f33517ff-2a88-4f6e-b855-c550268ce08a'
 ```
 
-#### personalisation (optional)
+##### personalisation (optional)
 
 If a template has placeholder fields for personalised information such as name or application date, you must provide their values in a hash. For example:
 
@@ -926,7 +926,7 @@ personalisation: {
 
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client::TemplatePreview` object. In the example shown in the [Method section](#generate-a-preview-template-method), the object is named `response`.
 
@@ -941,7 +941,7 @@ You can then call different methods on this object to return the requested infor
 |`response.type`|Template type (sms/email/letter)|String|
 |`response.html`|Body as rendered HTML (email only)|String|
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client raises a `Notifications::Client::RequestError` exception (or a subclass), which contains a code:
 
@@ -952,7 +952,7 @@ If the request is not successful, the client raises a `Notifications::Client::Re
 |`403`|`AuthError: Error: Your system clock must be accurate to within 30 seconds`|`AuthError`|Check your system clock|
 |`403`|`AuthError: Invalid token: API key not found`|`AuthError`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 
-# Get received text messages
+## Get received text messages
 
 This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
@@ -960,13 +960,13 @@ You can only get the status of messages that are 7 days old or newer.
 
 You can also set up [callbacks](#callbacks) for received text messages.
 
-## Enable received text messages
+### Enable received text messages
 
 Contact the GOV.UK Notify team using the [support page](https://www.notifications.service.gov.uk/support) or [chat to us on Slack](https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC) to request a unique number for text message replies.
 
-## Get a page of received text messages
+### Get a page of received text messages
 
-### Method
+#### Method
 
 ```ruby
 args = {
@@ -979,9 +979,9 @@ To get older messages, pass the ID of an older notification into the `older_than
 
 If you leave out the `older_than` argument, the client returns the most recent 250 notifications.
 
-### Arguments
+#### Arguments
 
-#### older_than (optional)
+##### older_than (optional)
 
 Input the ID of a received text message into this argument. If you use this argument, the client returns the next 250 received text messages older than the given ID. For example:
 
@@ -993,7 +993,7 @@ If you leave out the `older_than` argument, the client returns the most recent 2
 
 The client only returns notifications that are 7 days old or newer. If the notification specified in this argument is older than 7 days, the client returns an empty `collection` response.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client::ReceivedTextCollection` object. In the example shown in the [Method section](#get-a-page-of-received-text-messages-method), the object is named `response`.
 
@@ -1017,7 +1017,7 @@ If you call the `collection` method on this object to return an array, you must 
 
 If the notification specified in the `older_than` argument is older than 7 days, the client returns an empty `collection` response.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client raises a `Notifications::Client::RequestError` exception (or a subclass), which contains a code:
 


### PR DESCRIPTION
This changes the headings so that there is only one H1 heading. This is part of the work to make the tech docs headings accessible.
