### PR TITLE
Remove broken task to clean up Docker containers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Unless you're part of the GOV.UK Notify team, you won't be able to run this comm
 
 There are unit and integration tests that can be run to test functionality of the client.
 
-## Unit Tests
+### Unit Tests
 
 To run the unit tests:
 
@@ -36,7 +36,7 @@ To run the unit tests:
 make test-with-docker
 ```
 
-## Integration Tests
+### Integration Tests
 
 To run the integration tests:
 

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,5 @@ publish-to-rubygems: ## Create gemspec file and publish to rubygems
 	gem build notifications-ruby-client.gemspec --output=release.gem
 	gem push release.gem
 
-.PHONY: clean-docker-containers
-clean-docker-containers: ## Clean up any remaining docker containers
-	docker rm -f $(shell docker ps -q -f "name=${DOCKER_CONTAINER_PREFIX}") 2> /dev/null || true
-
 clean:
 	rm -rf vendor


### PR DESCRIPTION
The '--rm' flag in the 'run_with_docker.sh' script means containers
 should clean themselves up automatically. If we need a command to
clean up Docker containers more generally, we should document this
centrally, rather than in each repo.


<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number (in `lib/notifications/client/version.rb`)