### PR TITLE
Avoid baking environment.sh secrets into images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+environment*.sh


### PR DESCRIPTION
In response to [1].

Although this image is only used locally (and the one on CI is built
in a clean working directory), it's reasonable to add an extra layer
of protection to stop any secrets making their way into images.

[1]: https://github.com/alphagov/notifications-functional-tests/pull/382#pullrequestreview-702069161


<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number (in `lib/notifications/client/version.rb`)