### PR TITLE
Add details of ‘confirm email address’ and ‘custom retention period’

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -299,7 +299,7 @@ From 29 March 2023, we will turn this feature on by default for every file you s
 
 To use this feature before 29 March 2023 you will need version X.X.X of the Ruby client library, or a more recent version.
 
-To make the recipient confirm their email address before downloading the file, set the `verify_email_before_download` flag to `True`.
+To make the recipient confirm their email address before downloading the file, set the `confirm_email_before_download` flag to `true`.
 
 You will not need to do this after 29 March.
 
@@ -309,7 +309,7 @@ File.open("file.pdf", "rb") do |f|
     personalisation: {
       first_name: "Amala",
       application_date: "2018-01-01",
-      link_to_file: Notifications.prepare_upload(f),
+      link_to_file: Notifications.prepare_upload(f, confirm_email_before_download: true),
     }
 end
 ```
@@ -326,7 +326,7 @@ You should not turn this feature off if you send files that contain:
 * commercially sensitive information
 * information classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the [Government Security Classifications](https://www.gov.uk/government/publications/government-security-classifications) policy
 
-To let the recipient download the file without confirming their email address, set the `verify_email_before_download` flag to `False`.
+To let the recipient download the file without confirming their email address, set the `confirm_email_before_download` flag to `false`.
 
 
 
@@ -336,7 +336,7 @@ File.open("file.pdf", "rb") do |f|
     personalisation: {
       first_name: "Amala",
       application_date: "2018-01-01",
-      link_to_file: Notifications.prepare_upload(f),
+      link_to_file: Notifications.prepare_upload(f, confirm_email_before_download: false),
     }
 end
 ```
@@ -357,7 +357,7 @@ File.open("file.pdf", "rb") do |f|
     personalisation: {
       first_name: "Amala",
       application_date: "2018-01-01",
-      link_to_file: Notifications.prepare_upload(f),
+      link_to_file: Notifications.prepare_upload(f, retention_period: '52 weeks'),
     }
 end
 ```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -227,11 +227,14 @@ To send a file by email, add a placeholder to the template then upload a file. T
 
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
 
-For added security, you can ask recipients to confirm their email address before they can download the file.
+Your file will be available to download for a default period of 78 weeks (18 months). From 29 March 2023 we will reduce this to 26 weeks (6 months) for all new files. Files sent before 29 March will not be affected.
 
-You can also choose the length of time that a file is available to download. The default period is 78 weeks (18 months).
+To help protect your files you can also:
 
-From 29 March 2023 we will reduce this to 26 weeks (6 months) for all new files.
+* ask recipients to confirm their email address before downloading
+* choose the length of time that a file is available to download
+
+To turn these features on or off, you will need version X.X.X of the Ruby client library or a more recent version.
 
 #### Add contact details to the file download page
 
@@ -286,13 +289,19 @@ end
 
 #### Ask recipients to confirm their email address before they can download the file
 
-This feature is currently opt-in only. From 29 March 2023 it will apply to all new files by default, unless you opt out.
+This new security feature is optional. You should use it if you send files that are sensitive - for example, because they contain personal information about your users.
 
-##### Opt in
+When a recipient clicks the link in the email you’ve sent them, they have to enter their email address. Only someone who knows the recipient’s email address can download the file.
 
-To ask recipients to confirm their email address, set the `verify_email_before_download` flag to `true`.
+From 29 March 2023, we will turn this feature on by default for every file you send. Files sent before 29 March will not be affected.
 
-You will not need to do this after 29 March 2023.
+##### Turn on email address check
+
+To use this feature before 29 March 2023 you will need version X.X.X of the Ruby client library, or a more recent version.
+
+To make the recipient confirm their email address before downloading the file, set the `verify_email_before_download` flag to `True`.
+
+You will not need to do this after 29 March.
 
 ```ruby
 File.open("file.pdf", "rb") do |f|
@@ -305,11 +314,21 @@ File.open("file.pdf", "rb") do |f|
 end
 ```
 
-##### Opt out (not recommended)
+##### Turn off email address check (not recommended)
 
-You should not opt out if you send files that contain personally identifiable information or sensitive information.
+If you do not want to use this feature after 29 March 2023, you can turn it off on a file-by-file basis.
 
-If you do not want to use this security feature, set the `verify_email_before_download` flag to `false` by 29 March 2023.
+To do this you will need version X.X.X of the Ruby client library, or a more recent version.
+
+You should not turn this feature off if you send files that contain:
+
+* personally identifiable information
+* commercially sensitive information
+* information classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the [Government Security Classifications](https://www.gov.uk/government/publications/government-security-classifications) policy
+
+To let the recipient download the file without confirming their email address, set the `verify_email_before_download` flag to `False`.
+
+
 
 ```ruby
 File.open("file.pdf", "rb") do |f|
@@ -328,7 +347,9 @@ Set the number of weeks you want the file to be available using the `retention_p
 
 You can choose any value between 1 week and 78 weeks.
 
-If you do not do this, the file will be available for the default period of 78 weeks (18 months).
+To use this feature will need version X.X.X of the Ruby client library, or a more recent version.
+
+If you do not choose a value, the file will be available for the default period of 78 weeks (18 months).
 
 ```ruby
 File.open("file.pdf", "rb") do |f|

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -225,9 +225,13 @@ You can leave out this argument if your service only has one email reply-to addr
 
 To send a file by email, add a placeholder to the template then upload a file. The placeholder will contain a secure link to download the file.
 
-The file will be available for the recipient to download for 18 months.
-
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
+
+For added security, you can ask recipients to confirm their email address before they can download the file.
+
+You can also choose the length of time that a file is available to download. The default period is 78 weeks (18 months).
+
+From 29 March 2023 we will reduce this to 26 weeks (6 months) for all new files.
 
 #### Add contact details to the file download page
 
@@ -241,9 +245,9 @@ The links are unique and unguessable. GOV.UK Notify cannot access or decrypt you
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
 1. Select __Edit__.
-1. Add a placeholder to the email template using double brackets. For example:
+1. Add a placeholder to the email template using double brackets. For example: "Download your file at: ((link_to_file))"
 
-"Download your file at: ((link_to_file))"
+Your email should also tell recipients how long the file will be available to download.
 
 #### Upload your file
 
@@ -276,6 +280,63 @@ File.open("file.csv", "rb") do |f|
       first_name: "Amala",
       application_date: "2018-01-01",
       link_to_file: Notifications.prepare_upload(f, is_csv=true),
+    }
+end
+```
+
+#### Ask recipients to confirm their email address before they can download the file
+
+This feature is currently opt-in only. From 29 March 2023 it will apply to all new files by default, unless you opt out.
+
+##### Opt in
+
+To ask recipients to confirm their email address, set the `verify_email_before_download` flag to `true`.
+
+You will not need to do this after 29 March 2023.
+
+```ruby
+File.open("file.pdf", "rb") do |f|
+    ...
+    personalisation: {
+      first_name: "Amala",
+      application_date: "2018-01-01",
+      link_to_file: Notifications.prepare_upload(f),
+    }
+end
+```
+
+##### Opt out (not recommended)
+
+You should not opt out if you send files that contain personally identifiable information or sensitive information.
+
+If you do not want to use this security feature, set the `verify_email_before_download` flag to `false` by 29 March 2023.
+
+```ruby
+File.open("file.pdf", "rb") do |f|
+    ...
+    personalisation: {
+      first_name: "Amala",
+      application_date: "2018-01-01",
+      link_to_file: Notifications.prepare_upload(f),
+    }
+end
+```
+
+#### Choose the length of time that a file is available to download
+
+Set the number of weeks you want the file to be available using the `retention_period` key.
+
+You can choose any value between 1 week and 78 weeks.
+
+If you do not do this, the file will be available for the default period of 78 weeks (18 months).
+
+```ruby
+File.open("file.pdf", "rb") do |f|
+    ...
+    personalisation: {
+      first_name: "Amala",
+      application_date: "2018-01-01",
+      link_to_file: Notifications.prepare_upload(f),
     }
 end
 ```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -234,7 +234,7 @@ To help protect your files you can also:
 * ask recipients to confirm their email address before downloading
 * choose the length of time that a file is available to download
 
-To turn these features on or off, you will need version X.X.X of the Ruby client library or a more recent version.
+To turn these features on or off, you will need version 5.4.0 of the Ruby client library or a more recent version.
 
 #### Add contact details to the file download page
 
@@ -297,7 +297,7 @@ From 29 March 2023, we will turn this feature on by default for every file you s
 
 ##### Turn on email address check
 
-To use this feature before 29 March 2023 you will need version X.X.X of the Ruby client library, or a more recent version.
+To use this feature before 29 March 2023 you will need version 5.4.0 of the Ruby client library, or a more recent version.
 
 To make the recipient confirm their email address before downloading the file, set the `confirm_email_before_download` flag to `true`.
 
@@ -318,7 +318,7 @@ end
 
 If you do not want to use this feature after 29 March 2023, you can turn it off on a file-by-file basis.
 
-To do this you will need version X.X.X of the Ruby client library, or a more recent version.
+To do this you will need version 5.4.0 of the Ruby client library, or a more recent version.
 
 You should not turn this feature off if you send files that contain:
 
@@ -347,7 +347,7 @@ Set the number of weeks you want the file to be available using the `retention_p
 
 You can choose any value between 1 week and 78 weeks.
 
-To use this feature will need version X.X.X of the Ruby client library, or a more recent version.
+To use this feature will need version 5.4.0 of the Ruby client library, or a more recent version.
 
 If you do not choose a value, the file will be available for the default period of 78 weeks (18 months).
 


### PR DESCRIPTION
# Do not merge until the new features are live

This PR updates the ‘Send a file by email’ section of the REST-API documentation.

There are 2 stories in the backlog which describe this work:

* [Update 'send a file by email' API client docs for 'email verification' flow](https://www.pivotaltracker.com/story/show/182942256)
* [Update 'send a file by email' API client docs for custom retention periods](https://www.pivotaltracker.com/story/show/182999152)
