### PR TITLE
Add support for send a file security features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.4.0
+
+* Add support for new security features when sending a file by email:
+  * `confirm_email_before_download` can be set to `true` to require the user to enter their email address before accessing the file.
+  * `retention_period` can be set to `<1-78> weeks` to set how long the file should be made available.
+
 ## 5.3.0
 
 * Added `letter_contact_block` as a new attribute of the `Notifications::Client::Template` class. This affects the responses from the `get_template_by_id`, `get_template_version` and `get_all_templates` methods.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -225,9 +225,16 @@ You can leave out this argument if your service only has one email reply-to addr
 
 To send a file by email, add a placeholder to the template then upload a file. The placeholder will contain a secure link to download the file.
 
-The file will be available for the recipient to download for 18 months.
-
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
+
+Your file will be available to download for a default period of 78 weeks (18 months). From 29 March 2023 we will reduce this to 26 weeks (6 months) for all new files. Files sent before 29 March will not be affected.
+
+To help protect your files you can also:
+
+* ask recipients to confirm their email address before downloading
+* choose the length of time that a file is available to download
+
+To turn these features on or off, you will need version 5.4.0 of the Ruby client library or a more recent version.
 
 #### Add contact details to the file download page
 
@@ -241,9 +248,9 @@ The links are unique and unguessable. GOV.UK Notify cannot access or decrypt you
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
 1. Select __Edit__.
-1. Add a placeholder to the email template using double brackets. For example:
+1. Add a placeholder to the email template using double brackets. For example: "Download your file at: ((link_to_file))"
 
-"Download your file at: ((link_to_file))"
+Your email should also tell recipients how long the file will be available to download.
 
 #### Upload your file
 
@@ -280,6 +287,81 @@ File.open("file.csv", "rb") do |f|
 end
 ```
 
+#### Ask recipients to confirm their email address before they can download the file
+
+This new security feature is optional. You should use it if you send files that are sensitive - for example, because they contain personal information about your users.
+
+When a recipient clicks the link in the email you’ve sent them, they have to enter their email address. Only someone who knows the recipient’s email address can download the file.
+
+From 29 March 2023, we will turn this feature on by default for every file you send. Files sent before 29 March will not be affected.
+
+##### Turn on email address check
+
+To use this feature before 29 March 2023 you will need version 5.4.0 of the Ruby client library, or a more recent version.
+
+To make the recipient confirm their email address before downloading the file, set the `confirm_email_before_download` flag to `true`.
+
+You will not need to do this after 29 March.
+
+```ruby
+File.open("file.pdf", "rb") do |f|
+    ...
+    personalisation: {
+      first_name: "Amala",
+      application_date: "2018-01-01",
+      link_to_file: Notifications.prepare_upload(f, confirm_email_before_download: true),
+    }
+end
+```
+
+##### Turn off email address check (not recommended)
+
+If you do not want to use this feature after 29 March 2023, you can turn it off on a file-by-file basis.
+
+To do this you will need version 5.4.0 of the Ruby client library, or a more recent version.
+
+You should not turn this feature off if you send files that contain:
+
+* personally identifiable information
+* commercially sensitive information
+* information classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the [Government Security Classifications](https://www.gov.uk/government/publications/government-security-classifications) policy
+
+To let the recipient download the file without confirming their email address, set the `confirm_email_before_download` flag to `false`.
+
+
+
+```ruby
+File.open("file.pdf", "rb") do |f|
+    ...
+    personalisation: {
+      first_name: "Amala",
+      application_date: "2018-01-01",
+      link_to_file: Notifications.prepare_upload(f, confirm_email_before_download: false),
+    }
+end
+```
+
+#### Choose the length of time that a file is available to download
+
+Set the number of weeks you want the file to be available using the `retention_period` key.
+
+You can choose any value between 1 week and 78 weeks.
+
+To use this feature will need version 5.4.0 of the Ruby client library, or a more recent version.
+
+If you do not choose a value, the file will be available for the default period of 78 weeks (18 months).
+
+```ruby
+File.open("file.pdf", "rb") do |f|
+    ...
+    personalisation: {
+      first_name: "Amala",
+      application_date: "2018-01-01",
+      link_to_file: Notifications.prepare_upload(f, retention_period: '52 weeks'),
+    }
+end
+```
+
 #### Response
 
 If the request to the client is successful, the client returns a `Notifications::Client:ResponseNotification` object. In the example shown in the [Method section](#send-an-email-method), the object is named `emailresponse`.
@@ -303,6 +385,8 @@ If the request is not successful, the client raises a `Notifications::Client::Re
 |`400`|`BadRequestError: Can't send to this recipient using a team-only API key`|`BadRequestError`|Use the correct type of [API key](#api-keys)|
 |`400`|`BadRequestError: Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode`|`BadRequestError`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
 |`400`|`BadRequestError: Unsupported file type '(FILE TYPE)'. Supported types are: '(ALLOWED TYPES)'`|`BadRequestError`|Wrong file type. You can only upload .pdf, .csv, .txt, .doc, .docx, .xlsx, .rtf or .odt files|
+|`400`|`BadRequestError: Unsupported value for retention_period '(PERIOD)'. Supported periods are from 1 to 78 weeks.`|Choose a period between 1 and 78 weeks|
+|`400`|`BadRequestError: Unsupported value for confirm_email_before_download: '(VALUE)'. Use a boolean true or false value.`|Use either true or false|
 |`400`|`BadRequestError: File did not pass the virus scan`|`BadRequestError`|The file contains a virus|
 |`400`|`BadRequestError: Send files by email has not been set up - add contact details for your service at https://www.notifications.service.gov.uk/services/(SERVICE ID)/service-settings/send-files-by-email`|`BadRequestError`|See how to [add contact details to the file download page](#add-contact-details-to-the-file-download-page)|
 |`400`|`BadRequestError: Can only send a file by email` | `BadRequestError`|Make sure you are using an email template|

--- a/lib/notifications/client/helper_methods.rb
+++ b/lib/notifications/client/helper_methods.rb
@@ -1,9 +1,14 @@
 require "base64"
 
 module Notifications
-  def self.prepare_upload(file, is_csv=false)
+  def self.prepare_upload(file, is_csv=false, confirm_email_before_download: nil, retention_period: nil)
     raise ArgumentError.new("File is larger than 2MB") if file.size > Client::MAX_FILE_UPLOAD_SIZE
 
-    { file: Base64.strict_encode64(file.read), is_csv: is_csv }
+    data = { file: Base64.strict_encode64(file.read), is_csv: is_csv }
+
+    data[:confirm_email_before_download] = confirm_email_before_download
+    data[:retention_period] = retention_period
+
+    data
   end
 end

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "5.3.0".freeze
+    VERSION = "5.4.0".freeze
   end
 end

--- a/spec/notifications/client/helper_methods_spec.rb
+++ b/spec/notifications/client/helper_methods_spec.rb
@@ -10,19 +10,29 @@ describe Notifications do
         result = Notifications.prepare_upload(f)
         f.rewind
 
-        expect(result).to eq(file: encoded_content, is_csv: false)
+        expect(result).to eq(file: encoded_content, is_csv: false, confirm_email_before_download: nil, retention_period: nil)
         expect(Base64.strict_decode64(encoded_content)).to eq(f.read)
       end
     end
 
     it "encodes a StringIO object" do
       input_string = StringIO.new("My document to send")
-      expect(Notifications.prepare_upload(input_string)).to eq(file: "TXkgZG9jdW1lbnQgdG8gc2VuZA==", is_csv: false)
+      expect(Notifications.prepare_upload(input_string)).to eq(file: "TXkgZG9jdW1lbnQgdG8gc2VuZA==", is_csv: false, confirm_email_before_download: nil, retention_period: nil)
     end
 
     it "allows is_csv to be set to true" do
       input_string = StringIO.new("My document to send")
-      expect(Notifications.prepare_upload(input_string, true)).to eq(file: "TXkgZG9jdW1lbnQgdG8gc2VuZA==", is_csv: true)
+      expect(Notifications.prepare_upload(input_string, true)).to eq(file: "TXkgZG9jdW1lbnQgdG8gc2VuZA==", is_csv: true, confirm_email_before_download: nil, retention_period: nil)
+    end
+
+    it "allows confirm_email_before_download to be set to true" do
+      input_string = StringIO.new("My document to send")
+      expect(Notifications.prepare_upload(input_string, confirm_email_before_download: true)).to eq(file: "TXkgZG9jdW1lbnQgdG8gc2VuZA==", is_csv: false, confirm_email_before_download: true, retention_period: nil)
+    end
+
+    it "allows retention_period to be set" do
+      input_string = StringIO.new("My document to send")
+      expect(Notifications.prepare_upload(input_string, retention_period: '1 weeks')).to eq(file: "TXkgZG9jdW1lbnQgdG8gc2VuZA==", is_csv: false, confirm_email_before_download: nil, retention_period: '1 weeks')
     end
 
     it "raises an error when the file size is too large" do


### PR DESCRIPTION
Adds optional parameters `confirm_email_before_download` and `retention_period` to the `prepare_upload` helper, to access new security features when sending a file by email.

Bumps the client version to 5.4.0

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
