### PR TITLE
Update guidance for length of time files are available

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -322,9 +322,12 @@ end
 
 Set the number of weeks you want the file to be available using the `retention_period` key.
 
-You can choose any value between 1 week and 78 weeks.
-
 To use this feature will need version 5.4.0 of the Ruby client library, or a more recent version.
+
+You can choose any value between 1 week and 78 weeks. When deciding this, you should consider:
+
+* the need to protect the recipient’s personal information
+* whether the recipient will need to download the file again later
 
 If you do not choose a value, the file will be available for the default period of 26 weeks (6 months).
 


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

Information Assurance asked us to recommend that services keep files available for as short a period as practically possible.

We were asked to include this in Notify’s terms and conditions, but agreed it would be more relevant and useful in the:

* Using Notify guidance
* API documentation

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
