### PR TITLE
Adjust integration test for precompiled letters

### DIFF
--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -447,7 +447,6 @@ end
 
 def expected_fields_in_precompiled_letter_notification_that_are_nil
   %w(
-    completed_at
     created_by_name
     email_address
     line_2


### PR DESCRIPTION
This removes `completed_at` from the list of fields that will always be `nil` for precompiled letters - whether or not this field is populated depends on the status of the notification.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - [ ] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_ruby.md)
  - [ ] `CHANGELOG.md`
- [ ] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
