### PR TITLE
Allow the `jwt` gem to be upgraded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.3.0
+* Update dependencies
+  * Permit the `jwt` gem to be upgraded to version 3
+  * Remove the `bundler` gem dependency
+  * Allow the `factory_bot` gem to be upgraded whilst keeping the restriction in place for Ruby versions below 3
+
 ## 6.2.0
 * Added fields related to cost data in response:
   * `is_cost_data_ready`: This field is true if cost data is ready, and false if it isn't (Boolean).

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "6.2.0".freeze
+    VERSION = "6.3.0".freeze
   end
 end

--- a/notifications-ruby-client.gemspec
+++ b/notifications-ruby-client.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "jwt", ">= 1.5", "< 3"
+  spec.add_runtime_dependency "jwt", ">= 1.5", "< 4"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.7"

--- a/notifications-ruby-client.gemspec
+++ b/notifications-ruby-client.gemspec
@@ -26,5 +26,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "webmock", "~> 3.4"
-  spec.add_development_dependency "factory_bot", "~> 6.1", "<6.4.5"
+  if RUBY_VERSION < '3.0.0'
+    spec.add_development_dependency "factory_bot", "~> 6.1", "< 6.4.5"
+  else
+    spec.add_development_dependency "factory_bot", "~> 6.1"
+  end
 end

--- a/notifications-ruby-client.gemspec
+++ b/notifications-ruby-client.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jwt", ">= 1.5", "< 3"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "webmock", "~> 3.4"


### PR DESCRIPTION
## What problem does the pull request solve?

The major version level of the `jwt` gem is now 3 and upgrading is prevented by the dependency limit in `notification-ruby-client`.

I have changed the gem dependencies:
* To allow version 3 of `jwt`
* To remove the restriction on the version of `bundler`
* To allow `factory_bot` to be upgraded with Ruby version 3+

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - [ ] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_ruby.md) __This file no longer exists__
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
