### PR TITLE
Addition to dockerfile to exclude .git directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+**/.git/*
 environment*.sh


### PR DESCRIPTION
## What
This change adds extra protection to prevent contents of the .git directory from being added to the image created during the build process.

## Why
This is to prevent accidental git secret exposure.