### PR TITLE
feat: sanitise personalisation field for emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.4.0
+
+* Add support for the optional `sanitise_content_for` parameter when sending email (list of personalisation placeholder keys to sanitise for Markdown). Documented on `Notifications::Client::Speaker#post`.
+* Add `sanitised_content` to the send-email response object (`Notifications::Client::ResponseNotification`). The API returns a JSON object (Ruby `Hash`): keys are personalisation placeholder names, and each value is another object with `unsanitised` and `sanitised` for placeholders that were rewritten; the object is empty when nothing changed. If the key is absent from the JSON, the client exposes `nil`.
+
 ## 6.3.0
 * Update dependencies
   * Permit the `jwt` gem to be upgraded to version 3

--- a/bin/test_client.rb
+++ b/bin/test_client.rb
@@ -112,7 +112,8 @@ def test_send_email_endpoint(client)
     personalisation: { "name" => "some name" },
     reference: "some reference",
     email_reply_to_id: ENV['EMAIL_REPLY_TO_ID'],
-    one_click_unsubscribe_url: "https://www.clovercouncil.gov.uk/unsubscribe?email_address=faye@example.com"
+    one_click_unsubscribe_url: "https://www.clovercouncil.gov.uk/unsubscribe?email_address=faye@example.com",
+    sanitise_content_for: ["name"]
   )
   test_notification_response_data_type(email_resp, 'email')
   email_resp
@@ -186,6 +187,10 @@ def test_notification_response_data_type(notification, message_type)
 
   if message_type == 'email'
     hash_key_should_not_be_nil(expected_fields_in_email_content, notification.send('content'), 'send_' + message_type + '.content')
+    unless sanitised_content_matches_email_send_api_response?(notification.sanitised_content)
+      raise 'contract test failed: sanitised_content should be a JSON object whose keys are placeholder names ' \
+            'and whose values are objects with unsanitised and sanitised (see notifications-api post v2/email response)'
+    end
   elsif message_type == 'sms'
     hash_key_should_not_be_nil(expected_fields_in_sms_content, notification.send('content'), 'send_' + message_type + '.content')
   elsif message_type == 'letter'
@@ -248,6 +253,19 @@ def test_get_pdf_for_letter(client, id)
 
   raise "pdf didn't become ready in time" if response.nil?
   raise "get_pdf_for_letter response for #{id} is not a PDF: #{response}" unless response.start_with?('%PDF-')
+end
+
+# POST /v2/notifications/email merges sanitised_content from the API: a JSON object mapping each changed
+# placeholder to { "unsanitised" => ..., "sanitised" => ... }. It is {} when no placeholders differ.
+def sanitised_content_matches_email_send_api_response?(sanitised_content)
+  return false unless sanitised_content.is_a?(Hash)
+
+  sanitised_content.all? do |placeholder_key, entry|
+    placeholder_key.is_a?(String) &&
+      entry.is_a?(Hash) &&
+      entry.key?('unsanitised') &&
+      entry.key?('sanitised')
+  end
 end
 
 def hash_key_should_not_be_nil(fields, obj, method_name)

--- a/lib/notifications/client.rb
+++ b/lib/notifications/client.rb
@@ -30,7 +30,8 @@ module Notifications
     end
 
     ##
-    # @see Notifications::Client::Speaker#post
+    # @see Notifications::Client::Speaker#post
+    # Optional email-only keys are documented on {Notifications::Client::Speaker#post}.
     # @return [ResponseNotification]
     def send_email(args)
       ResponseNotification.new(

--- a/lib/notifications/client/response_notification.rb
+++ b/lib/notifications/client/response_notification.rb
@@ -7,6 +7,7 @@ module Notifications
       content
       template
       uri
+      sanitised_content
     ).freeze
 
       attr_reader(*FIELDS)

--- a/lib/notifications/client/speaker.rb
+++ b/lib/notifications/client/speaker.rb
@@ -49,6 +49,8 @@ module Notifications
       #   id of the sender to be used for an sms notification
       # @option form_data [String] :one_click_unsubscribe_url
       #   link that end user can click to unsubscribe from the distribution list. We will pass this link in the email headers.
+      # @option form_data [Array<String>] :sanitise_content_for
+      #   email only: optional list of personalisation placeholder keys to sanitise for Markdown before the template is rendered.
       # @see #perform_request!
       def post(kind, form_data)
         request = Net::HTTP::Post.new(

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "6.3.0".freeze
+    VERSION = "6.4.0".freeze
   end
 end

--- a/spec/factories/notifications_client.rb
+++ b/spec/factories/notifications_client.rb
@@ -81,7 +81,8 @@ FactoryBot.define do
                         "version" => 1,
                         "uri" => "/v2/templates/f6895ff7-86e0-4d38-80ab-c9525856c3ff"
                       },
-        "uri" => "/notifications/aceed36e-6aee-494c-a09f-88b68904bad6"
+        "uri" => "/notifications/aceed36e-6aee-494c-a09f-88b68904bad6",
+        "sanitised_content" => {}
       }
     end
 

--- a/spec/notifications/client/email_notification_spec.rb
+++ b/spec/notifications/client/email_notification_spec.rb
@@ -35,6 +35,7 @@ describe Notifications::Client do
       content
       uri
       template
+      sanitised_content
     ).each do |field|
       it "expect to include #{field}" do
         expect(
@@ -46,6 +47,45 @@ describe Notifications::Client do
     it "hits the correct API endpoint" do
       expect(WebMock).to have_requested(:post, "https://#{uri.host}:#{uri.port}/v2/notifications/email").
         with(body: { email_address: "email@gov.uk", template_id: "f6895ff7-86e0-4d38-80ab-c9525856c3ff" })
+    end
+
+    context "when sanitise_content_for is passed" do
+      let!(:sent_email) {
+        client.send_email(
+          email_address: "email@gov.uk",
+          template_id: "f6895ff7-86e0-4d38-80ab-c9525856c3ff",
+          sanitise_content_for: ["user_name"]
+        )
+      }
+
+      it "includes sanitise_content_for in the JSON request body" do
+        expect(WebMock).to have_requested(:post, "https://#{uri.host}:#{uri.port}/v2/notifications/email").with { |req|
+          body = JSON.parse(req.body)
+          body["sanitise_content_for"] == ["user_name"] &&
+            body["email_address"] == "email@gov.uk" &&
+            body["template_id"] == "f6895ff7-86e0-4d38-80ab-c9525856c3ff"
+        }
+      end
+    end
+
+    context "when sanitise_content_for is an empty array" do
+      let!(:sent_email) {
+        client.send_email(
+          email_address: "email@gov.uk",
+          template_id: "f6895ff7-86e0-4d38-80ab-c9525856c3ff",
+          sanitise_content_for: []
+        )
+      }
+
+      it "serialises sanitise_content_for as an empty JSON array" do
+        expect(WebMock).to have_requested(:post, "https://#{uri.host}:#{uri.port}/v2/notifications/email").with { |req|
+          JSON.parse(req.body)["sanitise_content_for"] == []
+        }
+      end
+    end
+
+    it "exposes sanitised_content as a Hash (JSON object), which may be empty when nothing was sanitised" do
+      expect(sent_email.sanitised_content).to be_a(Hash)
     end
   end
 end


### PR DESCRIPTION
## Summary
Added optional `sanitise_content_for` for send-email  and `sanitised_content `on the response. Tests, changelog, and version bump included.

Ran full integration tests and they pass.

## Checklist
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - [x] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_ruby.md)
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number (in `lib/notifications/client/version.rb`)
