### PR TITLE
Add cooldown to `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source 'https://rubygems.org', cooldown: 7
 
 gemspec


### PR DESCRIPTION
Sets a 7 day cooldown, similar to what we have for dependencies in other languages.

Context: https://blog.rubygems.org/2026/06/03/cooldown-let-new-gems-be-vetted.html

