### PR TITLE
feat: add personalisation to template responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.5.0
+
+* Add `personalisation` to the `Notifications::Client::Template` object returned by `get_template_by_id`, `get_template_version` and `get_all_templates`. This is a hash of placeholder names, for example `{"name" => {"required" => true}}`.
+
 ## 6.4.0
 
 * Add support for the optional `sanitise_content_for` parameter when sending email (list of personalisation placeholder keys to sanitise for Markdown). Documented on `Notifications::Client::Speaker#post`.

--- a/lib/notifications/client/response_template.rb
+++ b/lib/notifications/client/response_template.rb
@@ -14,6 +14,7 @@ module Notifications
         body
         subject
         letter_contact_block
+        personalisation
       ).freeze
 
       attr_reader(*FIELDS)

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "6.4.0".freeze
+    VERSION = "6.5.0".freeze
   end
 end

--- a/spec/factories/template_response.rb
+++ b/spec/factories/template_response.rb
@@ -16,7 +16,8 @@ FactoryBot.define do
         "body" => "Contents of template ((place_holder))",
         "subject" => "Subject of the letter",
         "version" => "2",
-        "letter_contact_block" => "The return address"
+        "letter_contact_block" => "The return address",
+        "personalisation" => {"place_holder" => {"required" => true}}
       }
     end
   end

--- a/spec/notifications/client/get_template_spec.rb
+++ b/spec/notifications/client/get_template_spec.rb
@@ -42,6 +42,7 @@ describe Notifications::Client do
       subject
       version
       letter_contact_block
+      personalisation
     ).each do |field|
       it "expect to include #{field}" do
         expect(
@@ -52,6 +53,10 @@ describe Notifications::Client do
 
     it "parses the time correctly" do
       expect(template.created_at.to_s).to eq("2016-11-29 11:12:30 UTC")
+    end
+
+    it "returns the personalisation placeholders" do
+      expect(template.personalisation).to eq("place_holder" => {"required" => true})
     end
 
     it "hits the correct API endpoint" do

--- a/spec/notifications/client/get_template_version_spec.rb
+++ b/spec/notifications/client/get_template_version_spec.rb
@@ -44,6 +44,7 @@ describe Notifications::Client do
       subject
       version
       letter_contact_block
+      personalisation
     ).each do |field|
       it "expect to include #{field}" do
         expect(


### PR DESCRIPTION
## Summary
- `Notifications::Client::Template` now exposes `personalisation` from get template responses.
