### PR TITLE
fix: get the gem publishing again after the Docker build failed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 **/.git/*
 environment*.sh
+Gemfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+## 6.5.1
+
+* Same contents as 6.5.0. That version was never published because the CI image failed to build after Debian 11 LTS ended.
+* Move the CI Docker image from `ruby:2.6-slim` (Debian 11) to `ruby:3.4-slim`. This does not change the gem for users.
+
 ## 6.5.0
 
 * Add `personalisation` to the `Notifications::Client::Template` object returned by `get_template_by_id`, `get_template_version` and `get_all_templates`. This is a hash of placeholder names, for example `{"name" => {"required" => true}}`.
+* Not published to RubyGems. Use 6.5.1.
 
 ## 6.4.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM ruby:2.6-slim
+FROM ruby:3.4-slim
 
 RUN \
 	echo "Install Debian packages" \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		awscli \
-		gcc \
-		make \
+		build-essential \
 		curl \
 		git \
 		gnupg \

--- a/lib/notifications/client/version.rb
+++ b/lib/notifications/client/version.rb
@@ -9,6 +9,6 @@
 
 module Notifications
   class Client
-    VERSION = "6.5.0".freeze
+    VERSION = "6.5.1".freeze
   end
 end


### PR DESCRIPTION
## What problem does the pull request solve?

`6.5.0` never got published. [Concourse failed while building the Docker image](https://concourse.notify.tools/teams/notify/pipelines/api-clients/jobs/build-ruby-client-tests-image-main/builds/25), before it could push the gem.


The image used `ruby:2.6-slim` (Debian 11). Debian 11 support [ended on 31 August 2026](https://www.debian.org/News/2026/20260831), so the image can no longer install packages in the usual way.

This PR moves the CI Docker image to `ruby:3.4-slim` and installs `build-essential` so native test gems can compile. It also bumps the version to `6.5.1` so Concourse can publish.

This only changes how we build, test, and publish, not the gem for users. Anyone using the Docker image locally will need to run `make bootstrap-with-docker` again.

## Checklist

- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - [ ] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_ruby.md)
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number (in `lib/notifications/client/version.rb`)